### PR TITLE
[dev] `metil.storyboard`:fix_sizing

### DIFF
--- a/storyboards/metil.storyboard
+++ b/storyboards/metil.storyboard
@@ -101,13 +101,13 @@
 
             <rect
               key="contentRect"
-              width="1"
-              height="1"
+              width="1920"
+              height="1204"
             />
             <rect
               key="screenRect"
-              width="1"
-              height="1"
+              width="1920"
+              height="1204"
             />
 
             <connections>
@@ -148,7 +148,7 @@
             <rect
               key="frame"
               width="1920"
-              height="1199"
+              height="1204"
             />
           </view>
         </viewController>


### PR DESCRIPTION
- `metil.storyboard`
- - expand->{`height`}.in_accordance_with->{`macos`:version_26.0};
- - match_sizing.of->{`content_rect`|`screen_rect`}.to->{`frame`};