### PR TITLE
[dev|enh] `metil_object_buffers_initialize`:with_parameter_index_name_change

### DIFF
--- a/include/metil_object.h
+++ b/include/metil_object.h
@@ -22,6 +22,11 @@ void metil_object_initialize(
   struct metil_object* _Nonnull
 );
 
+void metil_object_buffers_initialize(
+  struct metil_object* _Nonnull,
+  _Nonnull id<MTLDevice>
+);
+
 void metil_object_destroy(
   struct metil_object* _Nonnull
 );

--- a/include/metil_rendering/metil_renderer_vertex_index_parameter.h
+++ b/include/metil_rendering/metil_renderer_vertex_index_parameter.h
@@ -2,8 +2,8 @@
 #define __metil_renderer_vertex_index_parameter_h
 
 enum metil_renderer_vertex_index_parameter {
-  metil_renderer_vertex_index_parameter_data = 0,
-  metil_renderer_vertex_index_parameter_frame_data = 1,
+  metil_renderer_vertex_index_parameter_data_object = 0,
+  metil_renderer_vertex_index_parameter_data_frame = 1,
   metil_renderer_vertex_index_parameter_positions = 2
 };
 

--- a/include/metil_scenes/scene.h
+++ b/include/metil_scenes/scene.h
@@ -8,9 +8,9 @@
 
 struct metil_scene;
 
-typedef void (*metil_function_scene_poll)(struct metil_scene*);
-typedef void (*metil_function_scene_poll_input)(struct metil_scene*);
-typedef void (*metil_function_scene_destroy)(struct metil_scene*);
+typedef void (*metil_function_scene_poll)(struct metil_scene* _Nonnull);
+typedef void (*metil_function_scene_poll_input)(struct metil_scene* _Nonnull);
+typedef void (*metil_function_scene_destroy)(struct metil_scene* _Nonnull);
 
 enum metil_scene_type {
   metil_scene_type_unknown,
@@ -24,17 +24,17 @@ struct metil_scene_rendering_properties {
 };
 
 struct metil_scene {
-  id<MTLDevice> metal_kit_device;
+  _Nullable id<MTLDevice> metal_kit_device;
 
   struct metil_player player;
   enum metil_scene_type type;
   int id;
 
-  struct metil_object** objects;
-  unsigned short int length_objects;
+  struct metil_object* _Nonnull * _Nonnull objects;
+  unsigned int length_objects;
 
-  id<MTLTexture>* textures;
-  unsigned short int length_textures;
+  _Nonnull id<MTLTexture>* _Nonnull textures;
+  unsigned int length_textures;
 
   unsigned char loading;
 
@@ -49,44 +49,44 @@ struct metil_scene {
   unsigned long int time_input_previous;
   unsigned long int time_input_delta;
 
-  metil_function_scene_poll poll;
-  metil_function_scene_poll_input poll_input;
-  metil_function_scene_destroy destroy;
+  _Nonnull metil_function_scene_poll poll;
+  _Nonnull metil_function_scene_poll_input poll_input;
+  _Nonnull metil_function_scene_destroy destroy;
 
   struct metil_scene_rendering_properties rendering_properties;
 
-  void* data;
+  void* _Nullable data;
 };
 
 void metil_scene_initialize(
-  struct metil_scene*,
-  id<MTLDevice>
+  struct metil_scene* _Nonnull,
+  _Nullable id<MTLDevice>
 );
 
 void metil_scene_poll_input(
-  struct metil_scene*,
+  struct metil_scene* _Nonnull,
   unsigned long int
 );
 
 void metil_scene_poll(
-  struct metil_scene*,
+  struct metil_scene* _Nonnull,
   unsigned long int
 );
 
 void metil_scene_destroy(
-  struct metil_scene*
+  struct metil_scene* _Nonnull
 );
 
 void metil_scene_poll_input_default(
-  struct metil_scene*
+  struct metil_scene* _Nonnull
 );
 
 void metil_scene_poll_default(
-  struct metil_scene*
+  struct metil_scene* _Nonnull
 );
 
 void metil_scene_destroy_default(
-  struct metil_scene*
+  struct metil_scene* _Nonnull
 );
 
 #endif

--- a/metal/basic_2d_shaders.metal
+++ b/metal/basic_2d_shaders.metal
@@ -15,12 +15,12 @@ struct data_vertex {
   ]],
   constant struct metil_renderer_data_frame* data_frame [[
     buffer(
-      metil_renderer_vertex_index_parameter_frame_data
+      metil_renderer_vertex_index_parameter_data_frame
     )
   ]],
   constant struct metil_renderer_data_object* data_object [[
     buffer(
-      metil_renderer_vertex_index_parameter_data
+      metil_renderer_vertex_index_parameter_data_object
     )
   ]],
   unsigned int id_vertex [[vertex_id]]

--- a/metal/basic_3d_shaders.metal
+++ b/metal/basic_3d_shaders.metal
@@ -15,12 +15,12 @@ struct data_vertex {
   ]],
   constant struct metil_renderer_data_frame* data_frame [[
     buffer(
-      metil_renderer_vertex_index_parameter_frame_data
+      metil_renderer_vertex_index_parameter_data_frame
     )
   ]],
   constant struct metil_renderer_data_object* data_object [[
     buffer(
-      metil_renderer_vertex_index_parameter_data
+      metil_renderer_vertex_index_parameter_data_object
     )
   ]],
   unsigned int id_vertex [[vertex_id]]

--- a/metal/metil_fps_display.metal
+++ b/metal/metil_fps_display.metal
@@ -18,12 +18,12 @@ struct data_vertex {
   ]],
   constant struct metil_renderer_data_frame* data_frame [[
     buffer(
-      metil_renderer_vertex_index_parameter_frame_data
+      metil_renderer_vertex_index_parameter_data_frame
     )
   ]],
   constant struct metil_renderer_data_object* data_object [[
     buffer(
-      metil_renderer_vertex_index_parameter_data
+      metil_renderer_vertex_index_parameter_data_object
     )
   ]],
   unsigned int id_vertex [[vertex_id]]

--- a/sources/metil_object.m
+++ b/sources/metil_object.m
@@ -1,6 +1,7 @@
 #include <metil_object.h>
 
 #include <metil_mesh/mesh.h>
+#include <metil_rendering/metil_renderer_data_object.h>
 
 void metil_object_initialize(
   struct metil_object* metil_object
@@ -18,6 +19,28 @@ void metil_object_initialize(
   metil_object->rotation.x = 0.0f;
   metil_object->rotation.y = 0.0f;
   metil_object->rotation.z = 0.0f;
+}
+
+void metil_object_buffers_initialize(
+  struct metil_object* metil_object,
+  id<MTLDevice> metal_kit_device
+) {
+  metil_object->vertices = [metal_kit_device
+    newBufferWithBytes: metil_object->mesh.vertices
+    length: metil_object->mesh.length_vertices * sizeof(struct clic3_vector4_float)
+    options: MTLResourceStorageModeShared
+  ];
+
+  metil_object->indices = [metal_kit_device
+    newBufferWithBytes: metil_object->mesh.indices
+    length: metil_object->mesh.length_indices * sizeof(unsigned int)
+    options: MTLResourceStorageModeShared
+  ];
+
+  metil_object->data = [metal_kit_device
+    newBufferWithLength: sizeof(struct metil_renderer_data_object)
+    options: MTLResourceStorageModeShared
+  ];
 }
 
 void metil_object_destroy(

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -598,7 +598,7 @@ void* metil_renderer_on_initialize_data = (void*)0;
   [encoder_render
     setVertexBuffer: data_buffer_frame[index_data_buffer_frame]
     offset: 0
-    atIndex: metil_renderer_vertex_index_parameter_frame_data
+    atIndex: metil_renderer_vertex_index_parameter_data_frame
   ];
 
   [encoder_render
@@ -624,7 +624,7 @@ void* metil_renderer_on_initialize_data = (void*)0;
   [encoder_render
     setVertexBuffer: object->data
     offset: 0
-    atIndex: metil_renderer_vertex_index_parameter_data
+    atIndex: metil_renderer_vertex_index_parameter_data_object
   ];
   
   [encoder_render


### PR DESCRIPTION

- `metil_object_buffers_initialize`:add
- `enum metil_renderer_vertex_index_parameter`:refactor
- - `metil_renderer_vertex_index_parameter_data`->`metil_renderer_vertex_index_parameter_data_object`
- - `metil_renderer_vertex_index_parameter_frame_data`->`metil_renderer_vertex_index_parameter_data_frame`