### PR TITLE
[enh] add wireframe rendering mode with varaiable object texture lengths

### DIFF
--- a/examples/2d_rendering/sources/example_2d_rendering.m
+++ b/examples/2d_rendering/sources/example_2d_rendering.m
@@ -23,30 +23,11 @@ void example_2d_rendering_renderer_on_initialize(
   struct metil_renderer_interface* metil_renderer_interface,
   void* data
 ) {
-  metil_library.library = [
-    metil_renderer_interface->metal_device
-    newDefaultLibrary
-  ];
-
-  metil_library.function_vertex = [
-    metil_library.library
-    newFunctionWithName: @"shader_2d_vertex"
-  ];
-
-  metil_library.function_fragment = [
-    metil_library.library
-    newFunctionWithName: @"shader_2d_fragment"
-  ];
-
-  metil_library_fps_display_initialize(
+  metil_library_initialize(
     metil_renderer_interface->metal_device,
-    (void*)0
+    @"shader_2d_fragment",
+    @"shader_2d_vertex"
   );
-
-  metil_renderer_interface->rendering_properties->color_clear.x = 0.0f;
-  metil_renderer_interface->rendering_properties->color_clear.y = 0.0f;
-  metil_renderer_interface->rendering_properties->color_clear.z = 0.0f;
-  metil_renderer_interface->rendering_properties->color_clear.w = 1.0f;
 
   example_2d_scene_initialize(
     &metil_scene_controller.scene,

--- a/examples/3d_rendering/sources/example_3d_rendering.m
+++ b/examples/3d_rendering/sources/example_3d_rendering.m
@@ -23,29 +23,11 @@ void example_3d_rendering_renderer_on_initialize(
   struct metil_renderer_interface* metil_renderer_interface,
   void* data
 ) {
-  metil_library.library = [
-    metil_renderer_interface->metal_device newDefaultLibrary
-  ];
-
-  metil_library.function_vertex = [
-    metil_library.library
-    newFunctionWithName: @"shader_3d_vertex"
-  ];
-
-  metil_library.function_fragment = [
-    metil_library.library
-    newFunctionWithName: @"shader_3d_fragment"
-  ];
-
-  metil_library_fps_display_initialize(
+  metil_library_initialize(
     metil_renderer_interface->metal_device,
-    (void*)0
+    @"shader_3d_fragment",
+    @"shader_3d_vertex"
   );
-
-  metil_renderer_interface->rendering_properties->color_clear.x = 0.0f;
-  metil_renderer_interface->rendering_properties->color_clear.y = 0.0f;
-  metil_renderer_interface->rendering_properties->color_clear.z = 0.0f;
-  metil_renderer_interface->rendering_properties->color_clear.w = 1.0f;
 
   metil_renderer_interface->rendering_properties->camera.height = 0.0f;
 

--- a/examples/3d_rendering/sources/example_3d_scene.m
+++ b/examples/3d_rendering/sources/example_3d_scene.m
@@ -164,7 +164,7 @@ void example_3d_scene_poll(
 
     scene->objects[
       index_object
-    ]->position.z = 2;
+    ]->position.z = 2.0f;
 
     scene->objects[
       index_object

--- a/include/metil_library.h
+++ b/include/metil_library.h
@@ -4,22 +4,35 @@
 #include <Metal/MTLLibrary.h>
 
 struct metil_library {
-  id<MTLLibrary> library;
+  _Nonnull id<MTLLibrary> library;
+  _Nonnull id<MTLFunction> function_fragment;
+  _Nonnull id<MTLFunction> function_vertex;
 
-  id<MTLFunction> function_fragment;
-  id<MTLFunction> function_vertex;
+  _Nonnull id<MTLLibrary> library_fps_display;
+  _Nullable id<MTLFunction> function_fragment_fps_display;
+  _Nullable id<MTLFunction> function_vertex_fps_display;
 
-  id<MTLLibrary> library_fps_display;
-
-  id<MTLFunction> function_fragment_fps_display;
-  id<MTLFunction> function_vertex_fps_display;
+  _Nonnull id<MTLLibrary> library_wireframe;
+  _Nullable id<MTLFunction> function_fragment_wireframe;
+  _Nullable id<MTLFunction> function_vertex_wireframe;
 };
 
 extern struct metil_library metil_library;
 
+void metil_library_initialize(
+  _Nonnull id<MTLDevice>,
+  NSString* _Nonnull,
+  NSString* _Nonnull
+);
+
 void metil_library_fps_display_initialize(
-  id<MTLDevice>,
-  id<MTLLibrary>
+  _Nonnull id<MTLDevice>,
+  _Nullable id<MTLLibrary>
+);
+
+void metil_library_wireframe_initialize(
+  _Nonnull id<MTLDevice>,
+  _Nullable id<MTLLibrary>
 );
 
 #endif

--- a/include/metil_object.h
+++ b/include/metil_object.h
@@ -16,8 +16,8 @@ struct metil_object {
   _Nonnull id<MTLBuffer> indices;
   _Nonnull id<MTLBuffer> vertices;
 
-  _Nonnull id<MTLTexture> texture;
-  _Nullable id<MTLTexture> texture_secondary;
+  _Nonnull id<MTLTexture>* _Nonnull textures;
+  unsigned char length_textures;
 
   struct clic3_vector3_float position;
   struct clic3_vector3_float rotation;
@@ -37,6 +37,11 @@ void metil_object_initialize(
 void metil_object_buffers_initialize(
   struct metil_object* _Nonnull,
   _Nonnull id<MTLDevice>
+);
+
+void metil_object_texture_add(
+  struct metil_object* _Nonnull,
+  _Nullable id<MTLTexture>
 );
 
 void metil_object_destroy(

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -38,6 +38,7 @@ extern void* _Nullable metil_renderer_on_initialize_data;
 
 #define metil_renderer_pipelines_render_index_library 0
 #define metil_renderer_pipelines_render_index_fps_display 1
+#define metil_renderer_pipelines_render_index_wireframe 2
 
 @interface metil_renderer : NSObject<MTKViewDelegate> {
   id<MTLCommandQueue> command_queue;
@@ -101,7 +102,13 @@ extern void* _Nullable metil_renderer_on_initialize_data;
   function_vertex: (nonnull id<MTLFunction>) function_vertex;
 - (void) pipelines_clear;
 - (void) pipelines_initialize;
+- (void) pipeline_render_initialize:
+  (unsigned short int) index_pipeline_render
+  function_fragment: (nonnull id<MTLFunction>) function_fragment
+  function_vertex: (nonnull id<MTLFunction>) function_vertex;
 - (void) pipeline_render_fps_display_initiliaze;
+- (void) pipeline_render_library_initiliaze;
+- (void) pipeline_render_wireframe_initialize;
 
 - (void) mtkView: (nonnull MTKView*) metal_kit_view drawableSizeWillChange: (CGSize) size;
 
@@ -112,6 +119,18 @@ extern void* _Nullable metil_renderer_on_initialize_data;
 - (void) render;
 - (void) render_fps_display;
 - (void) render_object: (nonnull struct metil_object*) object;
+- (void) render_object_wireframe: (nonnull struct metil_object*) object;
+- (void) render_encode_draw:
+  (nonnull id<MTLBuffer>) vertices
+  indices: (nonnull id<MTLBuffer>) indices
+  length_indices: (unsigned int) length_indices
+  textures: (_Nonnull id<MTLTexture>* _Nullable) textures
+  length_textures: (unsigned char) length_textures
+  data: (nonnull id<MTLBuffer>) data
+  index_pipeline_render: (unsigned short int) index_pipeline_render
+  depth_disabled: (unsigned char) depth_disabled
+  type_primitive: (MTLPrimitiveType) type_primitive
+  type_index: (MTLIndexType) type_index;
 
 - (void) rendering_properties_initialize;
 

--- a/include/metil_rendering/rendering_properties.h
+++ b/include/metil_rendering/rendering_properties.h
@@ -11,6 +11,9 @@
 
 #define metil_count_time_frames 60
 
+#define metil_rendering_properties_mode_default 0b1
+#define metil_rendering_properties_mode_wireframe 0b10
+
 struct metil_rendering_properties {
   struct metil_camera camera;
 
@@ -25,6 +28,8 @@ struct metil_rendering_properties {
 
   unsigned char fps_display;
   float fps;
+
+  unsigned char mode;
 
   unsigned long int time_frames[metil_count_time_frames];
 };

--- a/makefile
+++ b/makefile
@@ -42,13 +42,16 @@ directory_metalar=metalar
 directory_macos_sdk=${shell xcrun --show-sdk-path}
 
 file_air_fps_display=${directory_air}/metil_fps_display.air
+file_air_wireframe=${directory_air}/metil_wireframe.air
 file_info_plist=Info.plist
 file_library=${directory_library}/${name}.o
 
 file_metalar_metil_all=${directory_metalar}/metil_all.metalar
 file_metalar_metil_fps_display=${directory_metalar}/metil_fps_display.metalar
+file_metalar_metil_wireframe=${directory_metalar}/metil_wireframe.metalar
 file_output_metalar_metil_all=${directory_library}/metil_all.metalar
 file_output_metalar_metil_fps_display=${directory_library}/metil_fps_display.metalar
+file_output_metalar_metil_wireframe=${directory_library}/metil_wireframe.metalar
 
 file_output_info_plist=${directory_library}/Info.plist
 file_output_metal=${directory_library}/metil.metallib
@@ -115,7 +118,7 @@ endif
 
 metal_flags_output=
 
-${name}: ${file_library} ${file_output_metal} ${file_output_metalar_metil_all} ${file_output_metalar_metil_fps_display} ${files_storyboards_compiled} ${file_output_info_plist}
+${name}: ${file_library} ${file_output_metal} ${file_output_metalar_metil_all} ${file_output_metalar_metil_fps_display} ${file_output_metalar_metil_wireframe} ${files_storyboards_compiled} ${file_output_info_plist}
 
 all: ${name} examples
 
@@ -144,6 +147,11 @@ ${file_metalar_metil_fps_display}: ${file_air_fps_display}
 	mkdir -p ${directory_metalar}
 	if [[ -f ${file_metalar_metil_fps_display} ]]; then rm ${file_metalar_metil_fps_display}; fi
 	${metal_ar} -rc ${file_metalar_metil_fps_display} ${file_air_fps_display}
+
+${file_metalar_metil_wireframe}: ${file_air_wireframe}
+	mkdir -p ${directory_metalar}
+	if [[ -f ${file_metalar_metil_wireframe} ]]; then rm ${file_metalar_metil_wireframe}; fi
+	${metal_ar} -rc ${file_metalar_metil_wireframe} ${file_air_wireframe}
 
 ${directory_air}/%.air: ${directory_metal}/%.metal
 	mkdir -p ${directory_air}

--- a/metal/metil_wireframe.metal
+++ b/metal/metil_wireframe.metal
@@ -1,0 +1,46 @@
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+#include <metal_stdlib>
+
+struct data_vertex {
+  float4 position [[position]];
+};
+
+[[vertex]] struct data_vertex metil_wireframe_vertex(
+  const device simd_float4* positions [[
+    buffer(
+      metil_renderer_vertex_index_parameter_positions
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    positions[id_vertex]
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 metil_wireframe_fragment() {
+  return float4(
+    1.0f,
+    1.0f,
+    1.0f,
+    1.0f
+  );
+}

--- a/readme.md
+++ b/readme.md
@@ -256,6 +256,26 @@ viewport rotations are set via `scene_controller.scene.player.rotation`
 - - positions and sizes the mesh in aboslute viewport units regardless of aspect ratio
 - - ex: `x: -1.0f, y: 1.0f` is top left, `x: 0.0f, y: 0.0f` is center, `x: 0.0f, y: -1.0f` is bottom center
 
+## `metil_rendering_properties->mode`
+
+- `metil_rendering_properties_mode_default`: normal rendering
+- `metil_rendering_properties_mode_wireframe`: renders wireframes (requires `metil_library.function_[fragment|vertex]_wireframe` to be set)
+
+Any combination of rendering mode flags may be set using `|` operators
+
+```c
+// Enable wireframe rendering overtop of default rendering
+metil_rendering_properties->mode = (
+  metil_rendering_properties_mode_default |
+  metil_rendering_properties_mode_wireframe
+);
+
+// Only render wireframes
+metil_rendering_properties->mode = (
+  metil_rendering_properties_mode_wireframe
+);
+```
+
 ## [data|control]->{flow}
 
 ```

--- a/sources/metil_library.m
+++ b/sources/metil_library.m
@@ -9,8 +9,44 @@ struct metil_library metil_library = {
 
   .library_fps_display = (void*)0,
   .function_fragment_fps_display = (void*)0,
-  .function_vertex_fps_display = (void*)0
+  .function_vertex_fps_display = (void*)0,
+
+  .library_wireframe = (void*)0,
+  .function_fragment_wireframe = (void*)0,
+  .function_vertex_wireframe = (void*)0
 };
+
+void metil_library_initialize(
+  id<MTLDevice> metal_device,
+  NSString* name_function_fragment,
+  NSString* name_function_vertex
+) {
+  if (
+    metil_library.library == (void*)0
+  ) {
+    metil_library.library = [metal_device newDefaultLibrary];
+  }
+
+  metil_library.function_fragment = [
+    metil_library.library
+    newFunctionWithName: name_function_fragment
+  ];
+
+  metil_library.function_vertex = [
+    metil_library.library
+    newFunctionWithName: name_function_vertex
+  ];
+
+  metil_library_fps_display_initialize(
+    metal_device,
+    metil_library.library
+  );
+
+  metil_library_wireframe_initialize(
+    metal_device,
+    metil_library.library
+  );
+}
 
 void metil_library_fps_display_initialize(
   id<MTLDevice> metal_device,
@@ -38,5 +74,34 @@ void metil_library_fps_display_initialize(
   metil_library.function_vertex_fps_display = [
     metil_library.library_fps_display
     newFunctionWithName: @"metil_fps_display_vertex"
+  ];
+}
+
+void metil_library_wireframe_initialize(
+  id<MTLDevice> metal_device,
+  id<MTLLibrary> library_wireframe
+) {
+  if (
+    library_wireframe != (void*)0
+  ) {
+    metil_library.library_wireframe = library_wireframe;
+  } else if (
+    metil_library.library != (void*)0
+  ) {
+    metil_library.library_wireframe = (
+      metil_library.library
+    );
+  } else {
+    metil_library.library_wireframe = [metal_device newDefaultLibrary];
+  }
+
+  metil_library.function_fragment_wireframe = [
+    metil_library.library_wireframe
+    newFunctionWithName: @"metil_wireframe_fragment"
+  ];
+
+  metil_library.function_vertex_wireframe = [
+    metil_library.library_wireframe
+    newFunctionWithName: @"metil_wireframe_vertex"
   ];
 }

--- a/sources/metil_object.m
+++ b/sources/metil_object.m
@@ -16,8 +16,12 @@ void metil_object_initialize(
   metil_object->data = (void*)0;
   metil_object->indices = (void*)0;
   metil_object->vertices = (void*)0;
-  metil_object->texture = (void*)0;
-  metil_object->texture_secondary = (void*)0;
+
+  metil_object->length_textures = 0;
+  metil_object->textures = malloc(
+    sizeof(id<MTLTexture>) *
+    metil_object->length_textures
+  );
 
   metil_object->position.x = 0.0f;
   metil_object->position.y = 0.0f;
@@ -57,6 +61,25 @@ void metil_object_buffers_initialize(
   ];
 }
 
+void metil_object_texture_add(
+  struct metil_object* metil_object,
+  id<MTLTexture> texture
+) {
+  metil_object->length_textures = (
+    metil_object->length_textures + 1
+  );
+
+  metil_object->textures = realloc(
+    metil_object->textures,
+    sizeof(id<MTLTexture>) *
+    metil_object->length_textures
+  );
+
+  metil_object->textures[
+    metil_object->length_textures - 1
+  ] = texture;
+}
+
 void metil_object_destroy(
   struct metil_object* object
 ) {
@@ -77,6 +100,8 @@ void metil_object_destroy(
   ) {
     [object->vertices release];
   }
+
+  free(object->textures);
 
   metil_mesh_destroy(
     &object->mesh

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -428,6 +428,13 @@ void* metil_renderer_on_initialize_data = (void*)0;
       ]
     );
 
+    metil_object_texture_add(
+      &self->objects_fps_display[
+        index_object_fps_display
+      ],
+      (void*)0
+    );
+
     self->objects_fps_display[
       index_object_fps_display
     ].position.y = 0.0f;
@@ -484,7 +491,7 @@ void* metil_renderer_on_initialize_data = (void*)0;
     ] = (void*)0;
   }
 
-  self->length_pipelines_render = 2;
+  self->length_pipelines_render = 3;
   self->pipelines_render = malloc(
     sizeof(id<MTLRenderPipelineState>) *
     self->length_pipelines_render
@@ -532,14 +539,14 @@ void* metil_renderer_on_initialize_data = (void*)0;
 
 - (void) pipelines_clear {
   for (
-    unsigned short int index_pipeline_render = 2;
+    unsigned short int index_pipeline_render = 3;
     index_pipeline_render < self->length_pipelines_render;
     ++index_pipeline_render
   ) {
     [self->pipelines_render[index_pipeline_render] release];
   }
 
-  self->length_pipelines_render = 2;
+  self->length_pipelines_render = 3;
   self->pipelines_render = realloc(
     self->pipelines_render,
     sizeof(id<MTLRenderPipelineState>) *
@@ -548,50 +555,57 @@ void* metil_renderer_on_initialize_data = (void*)0;
 }
 
 - (void) pipelines_initialize {
+  [self pipeline_render_fps_display_initiliaze];
+  [self pipeline_render_library_initiliaze];
+  [self pipeline_render_wireframe_initialize];
+}
+
+- (void) pipeline_render_initialize:
+  (unsigned short int) index_pipeline_render
+  function_fragment: (id<MTLFunction>) function_fragment
+  function_vertex: (id<MTLFunction>) function_vertex {
   if (
     self->pipelines_render[
-      metil_renderer_pipelines_render_index_library
+      index_pipeline_render
     ] == (void*) 0 &&
-    metil_library.function_fragment != (void*)0 &&
-    metil_library.function_vertex != (void*)0
+    function_fragment != (void*)0 &&
+    function_vertex != (void*)0
   ) {
-    self->descriptor_pipeline_render.fragmentFunction = metil_library.function_fragment;
-    self->descriptor_pipeline_render.vertexFunction = metil_library.function_vertex;
+    self->descriptor_pipeline_render.fragmentFunction = function_fragment;
+    self->descriptor_pipeline_render.vertexFunction = function_vertex;
 
     self->pipelines_render[
-      metil_renderer_pipelines_render_index_library
+      index_pipeline_render
     ] = [self->metal_device
       newRenderPipelineStateWithDescriptor: self->descriptor_pipeline_render
       error: (void*)0
     ];
   }
+}
 
-  [self pipeline_render_fps_display_initiliaze];
+
+- (void) pipeline_render_library_initiliaze {
+  [self
+    pipeline_render_initialize: metil_renderer_pipelines_render_index_library
+    function_fragment: metil_library.function_fragment
+    function_vertex: metil_library.function_vertex
+  ];
+}
+
+- (void) pipeline_render_wireframe_initialize {
+  [self
+    pipeline_render_initialize: metil_renderer_pipelines_render_index_wireframe
+    function_fragment: metil_library.function_fragment_wireframe
+    function_vertex: metil_library.function_vertex_wireframe
+  ];
 }
 
 - (void) pipeline_render_fps_display_initiliaze {
-  if (
-    self->pipelines_render[
-      metil_renderer_pipelines_render_index_fps_display
-    ] == (void*)0 &&
-    metil_library.function_vertex_fps_display != (void*)0 &&
-    metil_library.function_fragment_fps_display != (void*)0
-  ) {
-    self->descriptor_pipeline_render.vertexFunction = (
-      metil_library.function_vertex_fps_display
-    );
-
-    self->descriptor_pipeline_render.fragmentFunction = (
-      metil_library.function_fragment_fps_display
-    );
-
-    self->pipelines_render[
-      metil_renderer_pipelines_render_index_fps_display
-    ] = [self->metal_device
-      newRenderPipelineStateWithDescriptor: self->descriptor_pipeline_render
-      error: (void*)0
-    ];
-  }
+  [self
+    pipeline_render_initialize: metil_renderer_pipelines_render_index_fps_display
+    function_fragment: metil_library.function_fragment_fps_display
+    function_vertex: metil_library.function_vertex_fps_display
+  ];
 }
 
 - (void) poll: (unsigned int) _frame {
@@ -830,7 +844,7 @@ void* metil_renderer_on_initialize_data = (void*)0;
 
     self->objects_fps_display[
       index_object_fps_display
-    ].texture = metil_text_characters_default.textures[
+    ].textures[0] = metil_text_characters_default.textures[
       char_array_fps[index_object_fps_display]
     ];
 
@@ -854,7 +868,25 @@ void* metil_renderer_on_initialize_data = (void*)0;
     index_object < metil_scene_controller.scene.length_objects;
     ++index_object
   ) {
-    [self render_object: metil_scene_controller.scene.objects[index_object]];
+    if (
+      self->rendering_properties.mode & metil_rendering_properties_mode_default
+    ) {
+      [self
+        render_object: metil_scene_controller.scene.objects[
+          index_object
+        ]
+      ];
+    }
+
+    if (
+      self->rendering_properties.mode & metil_rendering_properties_mode_wireframe
+    ) {
+      [self
+        render_object_wireframe: metil_scene_controller.scene.objects[
+          index_object
+        ]
+      ];
+    }
   }
 }
 
@@ -872,67 +904,113 @@ void* metil_renderer_on_initialize_data = (void*)0;
   }
 }
 
-- (void) render_object: (struct metil_object*) object {
+- (void) render_encode_draw:
+  (id<MTLBuffer>) vertices
+  indices: (id<MTLBuffer>) indices
+  length_indices: (unsigned int) length_indices
+  textures: (id<MTLTexture>*) textures
+  length_textures: (unsigned char) length_textures
+  data: (id<MTLBuffer>) data
+  index_pipeline_render: (unsigned short int) index_pipeline_render
+  depth_disabled: (unsigned char) depth_disabled
+  type_primitive: (MTLPrimitiveType) type_primitive
+  type_index: (MTLIndexType) type_index
+{
   if (
-    index_pipelines_render_current != object->index_pipeline_render
+    self->index_pipelines_render_current != index_pipeline_render
   ) {
-    [encoder_render setRenderPipelineState: self->pipelines_render[
-      object->index_pipeline_render
-    ]];
+    [encoder_render
+      setRenderPipelineState: self->pipelines_render[
+        index_pipeline_render
+      ]
+    ];
   }
 
   if (
-    self->depth_state_disabled != object->depth_disabled
+    self->depth_state_disabled != depth_disabled
   ) {
     if (
-      object->depth_disabled == 0
+      depth_disabled == 0
     ) {
-      [encoder_render setDepthStencilState: self->depth_state];
+      [encoder_render
+        setDepthStencilState: self->depth_state
+      ];
     } else {
-      [encoder_render setDepthStencilState: self->depth_state_writes_disabled];
+      [encoder_render
+        setDepthStencilState: self->depth_state_writes_disabled
+      ];
     }
   }
 
   [encoder_render
-    setVertexBuffer: data_buffer_frame[
+    setVertexBuffer: self->data_buffer_frame[
       self->index_data_buffer_frame
     ]
     offset: 0
     atIndex: metil_renderer_vertex_index_parameter_data_frame
   ];
 
-  [encoder_render
-    setFragmentTexture: object->texture
-    atIndex: 0
-  ];
-
-  if (
-    object->texture_secondary != (void*)0
+  for (
+    unsigned char index_texture = 0;
+    index_texture < length_textures;
+    ++index_texture
   ) {
     [encoder_render
-      setFragmentTexture: object->texture_secondary
-      atIndex: 1
+      setFragmentTexture: textures[
+        index_texture
+      ]
+      atIndex: index_texture
     ];
   }
 
   [encoder_render
-    setVertexBuffer: object->vertices
+    setVertexBuffer: vertices
     offset: 0
     atIndex: metil_renderer_vertex_index_parameter_positions
   ];
 
   [encoder_render
-    setVertexBuffer: object->data
+    setVertexBuffer: data
     offset: 0
     atIndex: metil_renderer_vertex_index_parameter_data_object
   ];
 
   [encoder_render
-    drawIndexedPrimitives: object->type_primitive
-    indexCount: object->mesh.length_indices
-    indexType: object->type_index
-    indexBuffer: object->indices
+    drawIndexedPrimitives: type_primitive
+    indexCount: length_indices
+    indexType: type_index
+    indexBuffer: indices
     indexBufferOffset: 0
+  ];
+}
+
+- (void) render_object: (struct metil_object*) object {
+  [self
+    render_encode_draw: object->vertices
+    indices: object->indices
+    length_indices: object->mesh.length_indices
+    textures: object->textures
+    length_textures: object->length_textures
+    data: object->data
+    index_pipeline_render: object->index_pipeline_render
+    depth_disabled: object->depth_disabled
+    type_primitive: object->type_primitive
+    type_index: object->type_index
+  ];
+}
+
+- (void) render_object_wireframe: (struct metil_object*) object {
+  [self
+    render_encode_draw: object->vertices
+    indices: object->indices
+    length_indices: object->mesh.length_indices
+    textures: (void*)0
+    length_textures: 0
+    data: object->data
+    index_pipeline_render: metil_renderer_pipelines_render_index_wireframe
+    depth_disabled: object->depth_disabled
+    type_primitive: MTLPrimitiveTypeLineStrip
+    type_index: object->type_index
   ];
 }
 

--- a/sources/metil_rendering/rendering_properties.c
+++ b/sources/metil_rendering/rendering_properties.c
@@ -8,6 +8,10 @@
 void metil_rendering_properties_initialize(
   struct metil_rendering_properties* metil_rendering_properties
 ) {
+  metil_rendering_properties->mode = (
+    metil_rendering_properties_mode_default
+  );
+
   pthread_mutex_init(
     &metil_rendering_properties->mutex_frame,
     (void*)0


### PR DESCRIPTION
- add wireframe rendering mode
- add variable texture lengths to objects
- add metil_library primary initializer
- add section to readme about rendering modes 

<img width="1966" height="1250" alt="Screenshot 2025-10-17 at 04 38 52" src="https://github.com/user-attachments/assets/59da3f45-139c-4dae-beee-c526e3a7304f" />
<img width="1966" height="1250" alt="Screenshot 2025-10-17 at 04 39 03" src="https://github.com/user-attachments/assets/036fcb63-0bae-4286-96b0-e6a4f57d367b" />
<img width="1966" height="1250" alt="Screenshot 2025-10-17 at 04 39 17" src="https://github.com/user-attachments/assets/4e230621-4cc8-47c1-8476-36cbdfe37488" />
