### PR TITLE
[bug] `examples/*/makefile`:fix_missing->{`cer0_debug`:library};

### DIFF
--- a/examples/2d_rendering/makefile
+++ b/examples/2d_rendering/makefile
@@ -28,7 +28,6 @@ directory_sources=sources
 
 directory_cer0=../../../cer0
 directory_cer0_include=${directory_cer0}/include
-directory_cer0_library=${directory_cer0}/library
 
 directory_clic3=../../../clic3
 directory_clic3_include=${directory_clic3}/include
@@ -40,6 +39,7 @@ directory_math_c=../../../math_c
 
 directory_metil_include=${directory_metil}/include
 ifeq (${debug}, 1)
+	directory_cer0_library=${directory_cer0}/library_debug
 	directory_clic3_library=${directory_clic3}/library_debug
 	directory_interrupt_handler_library=${directory_interrupt_handler}/library_debug
 	directory_math_c_library=${directory_math_c}/library_debug
@@ -51,6 +51,7 @@ ifeq (${debug}, 1)
 	file_math_c_library=${directory_math_c_library}/math_c_debug.${version_target_math_c}.dylib
 	file_metil_library=${directory_metil_library}/metil_debug.${version_target_metil}.dylib
 else
+	directory_cer0_library=${directory_cer0}/library
 	directory_clic3_library=${directory_clic3}/library
 	directory_interrupt_handler_library=${directory_interrupt_handler}/library
 	directory_math_c_library=${directory_math_c}/library

--- a/examples/3d_rendering/makefile
+++ b/examples/3d_rendering/makefile
@@ -28,7 +28,6 @@ directory_sources=sources
 
 directory_cer0=../../../cer0
 directory_cer0_include=${directory_cer0}/include
-directory_cer0_library=${directory_cer0}/library
 
 directory_clic3=../../../clic3
 directory_clic3_include=${directory_clic3}/include
@@ -40,6 +39,7 @@ directory_math_c=../../../math_c
 
 directory_metil_include=${directory_metil}/include
 ifeq (${debug}, 1)
+	directory_cer0_library=${directory_cer0}/library_debug
 	directory_clic3_library=${directory_clic3}/library_debug
 	directory_interrupt_handler_library=${directory_interrupt_handler}/library_debug
 	directory_math_c_library=${directory_math_c}/library_debug
@@ -51,6 +51,7 @@ ifeq (${debug}, 1)
 	file_math_c_library=${directory_math_c_library}/math_c_debug.${version_target_math_c}.dylib
 	file_metil_library=${directory_metil_library}/metil_debug.${version_target_metil}.dylib
 else
+	directory_cer0_library=${directory_cer0}/library
 	directory_clic3_library=${directory_clic3}/library
 	directory_interrupt_handler_library=${directory_interrupt_handler}/library
 	directory_math_c_library=${directory_math_c}/library


### PR DESCRIPTION
- `examples/*/makefile`:fix_missing->{`cer0_debug`:library};