### PR TITLE
[enh] Metil 1 0 0 overridable default rendering property configurations

### DIFF
--- a/include/metil_configuration/configuration_rendering_properties.h
+++ b/include/metil_configuration/configuration_rendering_properties.h
@@ -1,8 +1,9 @@
 #ifndef __metil_configuration_rendering_properties_h
 #define __metil_configuration_rendering_properties_h
 
-extern const float metil_configuration_default_rendering_properties_brightness;
-extern const float metil_configuration_default_rendering_properties_brightness_text;
+extern float metil_configuration_default_rendering_properties_brightness;
+extern float metil_configuration_default_rendering_properties_brightness_text;
+extern unsigned char metil_configuration_default_rendering_properties_fps_display;
 
 struct metil_configuration_rendering_properties {
   float brightness;

--- a/sources/metil_configuration/configuration.m
+++ b/sources/metil_configuration/configuration.m
@@ -24,7 +24,9 @@ void metil_configuration_initialize() {
     metil_configuration_default_rendering_properties_brightness_text
   );
 
-  metil_configuration.rendering_properties.fps_display = 0;
+  metil_configuration.rendering_properties.fps_display = (
+    metil_configuration_default_rendering_properties_fps_display
+  );
 }
 
 unsigned char metil_configuration_load() {

--- a/sources/metil_configuration/configuration_rendering_properties.c
+++ b/sources/metil_configuration/configuration_rendering_properties.c
@@ -1,4 +1,6 @@
 #include <metil_configuration/configuration_rendering_properties.h>
 
-const float metil_configuration_default_rendering_properties_brightness = 1.0f;
-const float metil_configuration_default_rendering_properties_brightness_text = 1.0f;
+float metil_configuration_default_rendering_properties_brightness = 1.0f;
+float metil_configuration_default_rendering_properties_brightness_text = 1.0f;
+
+unsigned char metil_configuration_default_rendering_properties_fps_display = 0;


### PR DESCRIPTION
- `configuration_rendering_properties`:
- - allow overriding default values
- - add:`metil_configuration_default_rendering_properties_fps_display`