### PR TITLE
[bug] Metil 1 0 0 flip z axis

### DIFF
--- a/sources/metil_player.c
+++ b/sources/metil_player.c
@@ -143,7 +143,7 @@ void metil_player_poll_input(
     metil_input_cursor.locked == 1
   ) {
     player->rotation.y = (
-      player->rotation.y + (
+      player->rotation.y - (
         metil_input_cursor.delta.x / 50.0f *
         player->speed_rotation
       )
@@ -166,7 +166,7 @@ void metil_player_poll_input(
       metil_controller_state.right_stick.x <= -metil_player_deadzone_stick_default
     ) {
       player->rotation.y = (
-        player->rotation.y + (
+        player->rotation.y - (
           metil_controller_state.right_stick.x *
           player->speed_rotation
         )
@@ -201,7 +201,9 @@ void metil_player_poll_input(
     (M_PI * 2.0f)
   );
 
-  float ratio_axis = player->rotation.y / (M_PI * 2.0f);
+  float ratio_axis = -(
+    player->rotation.y / (M_PI * 2.0f)
+  );
 
   if (
     ratio_axis >= 0.0f &&

--- a/sources/metil_positioning.m
+++ b/sources/metil_positioning.m
@@ -69,7 +69,7 @@ void metil_positioning_view_model_matrix_projection_set(
         {
           position_translated.x,
           position_translated.y,
-          -position_translated.z,
+          position_translated.z,
           1
         }
       }},

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -662,9 +662,9 @@ void* metil_renderer_on_initialize_data = (void*)0;
     matrix_player_projection,
     (
       (matrix_float4x4) {{
-        { cos(metil_scene_controller.scene.player.rotation.y), 0.0f, -sin(metil_scene_controller.scene.player.rotation.y), 0.0f },
+        { cos(metil_scene_controller.scene.player.rotation.y), 0.0f, sin(metil_scene_controller.scene.player.rotation.y), 0.0f },
         { 0.0f, 1.0f, 0.0f, 0.0f },
-        { sin(metil_scene_controller.scene.player.rotation.y), 0.0f, cos(metil_scene_controller.scene.player.rotation.y), 0.0f },
+        { sin(metil_scene_controller.scene.player.rotation.y), 0.0f, -cos(metil_scene_controller.scene.player.rotation.y), 0.0f },
         { 0.0f, 0.0f, 0.0f, 1.0f }
       }}
     )


### PR DESCRIPTION
flips the z_axis so object positioning is 1:1 with player positioning rather than being inversely close