### PR TITLE
[bug] Metil 1 0 0 ios termination fixes | `metil_application_delegate`: ios fix

### DIFF
--- a/include/metil_application/metil_application_delegate.h
+++ b/include/metil_application/metil_application_delegate.h
@@ -2,9 +2,11 @@
 #define __metil_application_metil_application_delegate_h
 
 #if target_os_ios
-#include <UIKit/UIKit.h>
+#import <UIKit/UIKit.h>
 
-@interface metil_application_delegate: NSObject<UIApplicationDelegate>
+@interface metil_application_delegate: UIResponder <UIApplicationDelegate>
+
+@property (strong, nonatomic) UIWindow* window;
 
 #else
 #include <AppKit/AppKit.h>

--- a/readme.md
+++ b/readme.md
@@ -410,7 +410,7 @@ metil_rendering_properties->mode = (
 
 see [`usage->linking->[dynamic libraries | static libraries]`](#linking) for further information
 
-- [`alic3`](https://github.com/alic3dev):libraries
+- [`alic3dev`](https://github.com/alic3dev)
 - - [`cer0`](https://github.com/alic3dev/cer0)
 - - [`clic3`](https://github.com/alic3dev/clic3)
 - - [`interrupt_handler`](https://github.com/alic3dev/interrupt_handler)

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -24,7 +24,8 @@
 
 void metil_terminate_on_signal(int _) {
   #if target_os_ios
-  [[UIApplication sharedApplication] terminate: 0];
+  metil_termination_terminate();
+  exit(0);
   #else
   [[NSApplication sharedApplication] terminate: 0];
   #endif
@@ -82,7 +83,7 @@ int metil_initialize_with_data(
   ) {
     metil_paths_destroy();
     #if target_os_ios
-    [[UIApplication sharedApplication] terminate: 0];
+    exit(status_configuration_load);
     #else
     [[NSApplication sharedApplication] terminate: 0];
     #endif
@@ -114,12 +115,10 @@ int metil_initialize_with_data(
     (void*)0
   );
 
-  #if !target_os_ios
   metil_termination_on_function_add(
     metil_audio_destroy,
     (void*)0
   );
-  #endif
 
   metil_termination_on_function_add(
     metil_text_destroy,

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -219,7 +219,10 @@ void* metil_renderer_on_initialize_data = (void*)0;
   ) {
     [self->encoder_render endEncoding];
   }
+  
+  #if !target_os_ios
   [self->encoder_render release];
+  #endif
 
   for (
     unsigned char index_pipeline_render = 0;

--- a/sources/metil_termination.c
+++ b/sources/metil_termination.c
@@ -110,5 +110,11 @@ void metil_termination_terminate() {
     );
   }
 
-  free(metil_termination_on_functions);
+  free(
+    metil_termination_on_functions
+  );
+
+  free(
+    metil_termination_on_functions_data
+  );
 }


### PR DESCRIPTION
- fixes application delegate not working on ios, needed the `window` property
- changes termination calls to `exit` calls on ios
- for some reason trying to release the encoder on ios causes the entire application to lock up completely, so wrap that in a conditional for ios
- also free up `metil_termination_on_functions_data` on destroy
- and tack on `dev` to `alic3` in the readme