### PR TITLE
[dev] `metil_object_buffer`

### DIFF
--- a/examples/2d_rendering/sources/example_2d_scene.m
+++ b/examples/2d_rendering/sources/example_2d_scene.m
@@ -60,7 +60,9 @@ void example_2d_scene_initialize(
     );
 
     struct metil_renderer_data_object* data_object = (
-      object->data.contents
+      object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
     );
 
     data_object->color.x = (
@@ -110,7 +112,9 @@ void example_2d_scene_poll(
       (struct metil_object*) scene->renderables[
         index_renderable
       ].renderable
-    )->data.contents;
+    )->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents;
 
     struct clic3_vector3_unsigned_int time_offset = {
       .x = scene->time + (index_renderable + 2) * 20,

--- a/examples/3d_rendering/sources/example_3d_scene.m
+++ b/examples/3d_rendering/sources/example_3d_scene.m
@@ -73,7 +73,9 @@ void example_3d_scene_initialize(
     ) / 57.0f - 0.5f) * 1000.0f;
 
     struct metil_renderer_data_object* data_object = (
-      object->data.contents
+      object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
     );
 
     data_object->color.x = (
@@ -278,7 +280,9 @@ void example_3d_scene_initialize(
     );
 
     struct metil_renderer_data_object* data_object = (
-      object->data.contents
+      object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
     );
 
     data_object->color.x = (
@@ -339,10 +343,10 @@ void example_3d_scene_poll(
     }
 
     struct metil_renderer_data_object* data_object = (
-      object->data.contents
+      object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
     );
-
-
 
     data_object->color.x = (float) (index_renderable % 10) / 10.0f + color_shift;
     data_object->color.y = (float) ((index_renderable * 3) % 10) / 10.0f + color_shift;

--- a/examples/face/metal/face.metal
+++ b/examples/face/metal/face.metal
@@ -11,7 +11,7 @@ struct data_vertex {
 [[vertex]] struct data_vertex face_vertex(
   const device simd_float4* positions [[
     buffer(
-      metil_renderer_vertex_index_parameter_positions
+      metil_renderer_vertex_index_parameter_vertices
     )
   ]],
   constant struct metil_renderer_data_frame* data_frame [[

--- a/examples/face/metal/face_points.metal
+++ b/examples/face/metal/face_points.metal
@@ -12,7 +12,7 @@ struct data_vertex {
 [[vertex]] struct data_vertex face_points_vertex(
   const device simd_float4* positions [[
     buffer(
-      metil_renderer_vertex_index_parameter_positions
+      metil_renderer_vertex_index_parameter_vertices
     )
   ]],
   constant struct metil_renderer_data_frame* data_frame [[

--- a/examples/face/sources/example_face_scene.m
+++ b/examples/face/sources/example_face_scene.m
@@ -468,7 +468,9 @@ void example_face_scene_initialize(
   );
 
   struct example_face_renderer_data_object* data_object = (
-    object->data.contents
+    object->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
   );
 
   data_object->vertex_hovered = 0;
@@ -495,9 +497,37 @@ void example_face_scene_initialize(
 
   object_points->index_pipeline_render = example_face_pipeline_index_face_points;
 
-  object_points->vertices = object->vertices;
   object_points->indices = object->indices;
-  object_points->data = object->data;
+
+  for (
+    unsigned char index_buffer_vertex = 0;
+    index_buffer_vertex < object->length_buffers_vertex;
+    ++index_buffer_vertex
+  ) {
+    metil_object_buffers_add(
+      object_points,
+      scene->renderer_interface->metal_device,
+      metil_object_buffer_type_vertex
+    );
+
+    object_points->buffers_vertex[
+      index_buffer_vertex
+    ].buffer = object->buffers_vertex[
+      index_buffer_vertex
+    ].buffer;
+
+    object_points->buffers_vertex[
+      index_buffer_vertex
+    ].index = object->buffers_vertex[
+      index_buffer_vertex
+    ].index;
+
+    object_points->buffers_vertex[
+      index_buffer_vertex
+    ].offset = object->buffers_vertex[
+      index_buffer_vertex
+    ].offset;
+  }
 
   scene->poll = example_face_scene_poll;
 }
@@ -514,11 +544,15 @@ void example_face_scene_poll(
   );
 
   struct example_face_renderer_data_object* data_object = (
-    object->data.contents
+    object->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
   );
 
   struct clic3_vector4_float* vertices = (
-    object->vertices.contents
+    object->buffers_vertex[
+      metil_object_buffer_default_index_vertices
+    ].buffer.contents
   );
 
   data_object->vertex_hovered = 0;
@@ -633,9 +667,9 @@ void example_face_scene_destroy(
     ].renderable
   );
 
-  object_points->data = (void*) 0;
+  object_points->length_buffers_vertex = 0;
+
   object_points->indices = (void*) 0;
-  object_points->vertices = (void*) 0;
 
   metil_scene_destroy_default(
     scene

--- a/include/metil_object/metil_object.h
+++ b/include/metil_object/metil_object.h
@@ -2,6 +2,7 @@
 #define __metil_object_metil_object_h
 
 #include <metil_mesh/mesh.h>
+#include <metil_object/metil_object_buffer.h>
 #include <metil_positioning.h>
 #include <metil_rendering/camera/camera.h>
 
@@ -30,9 +31,13 @@ typedef void (*metil_object_destroy_function)(
 struct metil_object {
   struct metil_mesh mesh;
 
-  _Nonnull id<MTLBuffer> data;
+  struct metil_object_buffer* _Nonnull buffers_fragment;
+  struct metil_object_buffer* _Nonnull buffers_vertex;
+  
+  unsigned char length_buffers_vertex;
+  unsigned char length_buffers_fragment;
+
   _Nonnull id<MTLBuffer> indices;
-  _Nonnull id<MTLBuffer> vertices;
 
   MTLPrimitiveType type_primitive;
   MTLIndexType type_index;
@@ -57,6 +62,11 @@ void metil_object_initialize(
   struct metil_object* _Nonnull
 );
 
+void metil_object_indices_initialize(
+  struct metil_object* _Nonnull,
+  _Nonnull id<MTLDevice>
+);
+
 void metil_object_buffers_initialize_with_data_size(
   struct metil_object* _Nonnull,
   _Nonnull id<MTLDevice>,
@@ -66,6 +76,12 @@ void metil_object_buffers_initialize_with_data_size(
 void metil_object_buffers_initialize(
   struct metil_object* _Nonnull,
   _Nonnull id<MTLDevice>
+);
+
+void metil_object_buffers_add(
+  struct metil_object* _Nonnull,
+  _Nonnull id<MTLDevice>,
+  enum metil_object_buffer_type
 );
 
 void metil_object_texture_add(

--- a/include/metil_object/metil_object_buffer.h
+++ b/include/metil_object/metil_object_buffer.h
@@ -1,0 +1,22 @@
+#ifndef __metil_object_metil_object_buffer_h
+#define __metil_object_metil_object_buffer_h
+
+#include <Metal/MTLDevice.h>
+
+enum metil_object_buffer_default_index {
+  metil_object_buffer_default_index_data = 1,
+  metil_object_buffer_default_index_vertices = 0
+};
+
+enum metil_object_buffer_type {
+  metil_object_buffer_type_fragment = 0,
+  metil_object_buffer_type_vertex = 1
+};
+
+struct metil_object_buffer {
+  _Nonnull id<MTLBuffer> buffer;
+  unsigned int offset;
+  unsigned int index;
+};
+
+#endif

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -1,7 +1,8 @@
 #ifndef __metil_renderer_h
 #define __metil_renderer_h
 
-#include <metil_object.h>
+#include <metil_object/metil_object.h>
+#include <metil_object/metil_object_buffer.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_rendering/metil_renderer_thread_poll_object_data.h>
 #include <metil_rendering/rendering_properties.h>
@@ -112,12 +113,14 @@ extern void* _Nullable metil_renderer_on_initialize_data;
 - (void) render_object: (nonnull struct metil_object*) object;
 - (void) render_object_wireframe: (nonnull struct metil_object*) object;
 - (void) render_encode_draw:
-  (nonnull id<MTLBuffer>) vertices
+  (struct metil_object_buffer* _Nonnull) buffers_vertex
+  length_buffers_vertex: (unsigned int) length_buffers_vertex
+  buffers_fragment: (struct metil_object_buffer* _Nonnull) buffers_fragment
+  length_buffers_fragment: (unsigned int) length_buffers_fragment
   indices: (nonnull id<MTLBuffer>) indices
   length_indices: (unsigned int) length_indices
   textures: (_Nonnull id<MTLTexture>* _Nullable) textures
   length_textures: (unsigned char) length_textures
-  data: (nonnull id<MTLBuffer>) data
   index_pipeline_render: (unsigned short int) index_pipeline_render
   depth_disabled: (unsigned char) depth_disabled
   type_primitive: (MTLPrimitiveType) type_primitive

--- a/include/metil_rendering/metil_renderer_vertex_index_parameter.h
+++ b/include/metil_rendering/metil_renderer_vertex_index_parameter.h
@@ -2,9 +2,13 @@
 #define __metil_renderer_vertex_index_parameter_h
 
 enum metil_renderer_vertex_index_parameter {
-  metil_renderer_vertex_index_parameter_data_object = 0,
-  metil_renderer_vertex_index_parameter_data_frame = 1,
-  metil_renderer_vertex_index_parameter_positions = 2
+  metil_renderer_vertex_index_parameter_data_object = 2,
+  metil_renderer_vertex_index_parameter_data_frame = 0,
+  metil_renderer_vertex_index_parameter_vertices = 1
+};
+
+enum metil_renderer_fragment_index_parameter {
+  metil_renderer_fragment_index_parameter_data_frame = 0
 };
 
 #endif

--- a/metal/basic_2d_shaders.metal
+++ b/metal/basic_2d_shaders.metal
@@ -10,7 +10,7 @@ struct data_vertex {
 [[vertex]] struct data_vertex shader_2d_vertex(
   const device simd_float4* positions [[
     buffer(
-      metil_renderer_vertex_index_parameter_positions
+      metil_renderer_vertex_index_parameter_vertices
     )
   ]],
   constant struct metil_renderer_data_frame* data_frame [[

--- a/metal/basic_3d_shaders.metal
+++ b/metal/basic_3d_shaders.metal
@@ -10,7 +10,7 @@ struct data_vertex {
 [[vertex]] struct data_vertex shader_3d_vertex(
   const device simd_float4* positions [[
     buffer(
-      metil_renderer_vertex_index_parameter_positions
+      metil_renderer_vertex_index_parameter_vertices
     )
   ]],
   constant struct metil_renderer_data_frame* data_frame [[

--- a/metal/metil_fps_display.metal
+++ b/metal/metil_fps_display.metal
@@ -13,7 +13,7 @@ struct data_vertex {
 [[vertex]] struct data_vertex metil_fps_display_vertex(
   const device simd_float4* positions [[
     buffer(
-      metil_renderer_vertex_index_parameter_positions
+      metil_renderer_vertex_index_parameter_vertices
     )
   ]],
   constant struct metil_renderer_data_frame* data_frame [[

--- a/metal/metil_wireframe.metal
+++ b/metal/metil_wireframe.metal
@@ -11,7 +11,7 @@ struct data_vertex {
 [[vertex]] struct data_vertex metil_wireframe_vertex(
   const device simd_float4* positions [[
     buffer(
-      metil_renderer_vertex_index_parameter_positions
+      metil_renderer_vertex_index_parameter_vertices
     )
   ]],
   constant struct metil_renderer_data_frame* data_frame [[

--- a/sources/metil_object/metil_object.m
+++ b/sources/metil_object/metil_object.m
@@ -12,12 +12,25 @@
 #include <Metal/MTLRenderCommandEncoder.h>
 #include <Metal/MTLResource.h>
 
+#include <stdlib.h>
+
 void metil_object_initialize(
   struct metil_object* metil_object
 ) {
-  metil_object->data = (void*)0;
+  metil_object->length_buffers_fragment = 0;
+  metil_object->length_buffers_vertex = 0;  
+
+  metil_object->buffers_fragment = malloc(
+    sizeof(struct metil_object_buffer) *
+    metil_object->length_buffers_fragment
+  );
+
+  metil_object->buffers_vertex = malloc(
+    sizeof(struct metil_object_buffer) *
+    metil_object->length_buffers_vertex
+  );
+
   metil_object->indices = (void*)0;
-  metil_object->vertices = (void*)0;
 
   metil_object->type_primitive = MTLPrimitiveTypeTriangle;
   metil_object->type_index = MTLIndexTypeUInt32;
@@ -46,16 +59,10 @@ void metil_object_initialize(
   metil_object->destroy = metil_object_destroy;
 }
 
-void metil_object_buffers_initialize_with_data_size(
+void metil_object_indices_initialize(
   struct metil_object* metil_object,
-  id<MTLDevice> metal_device,
-  unsigned long int size_data
+  id<MTLDevice> metal_device
 ) {
-  metil_object->data = [metal_device
-    newBufferWithLength: size_data
-    options: MTLResourceStorageModeShared
-  ];
-
   metil_object->indices = [metal_device
     newBufferWithBytes: metil_object->mesh.indices
     length: (
@@ -64,13 +71,50 @@ void metil_object_buffers_initialize_with_data_size(
     )
     options: MTLResourceStorageModeShared
   ];
+}
 
-  metil_object->vertices = [metal_device
+void metil_object_buffers_initialize_with_data_size(
+  struct metil_object* metil_object,
+  id<MTLDevice> metal_device,
+  unsigned long int size_data
+) {
+  metil_object_indices_initialize(
+    metil_object,
+    metal_device
+  );
+
+  unsigned char offset_buffer = (
+    metil_object->length_buffers_vertex
+  );
+
+  metil_object_buffers_add(
+    metil_object,
+    metal_device,
+    metil_object_buffer_type_vertex
+  );
+
+  metil_object_buffers_add(
+    metil_object,
+    metal_device,
+    metil_object_buffer_type_vertex
+  );
+
+  metil_object->buffers_vertex[
+    offset_buffer
+  ].buffer = [metal_device
     newBufferWithBytes: metil_object->mesh.vertices
     length: (
       metil_object->mesh.length_vertices *
       sizeof(struct clic3_vector4_float)
     )
+    options: MTLResourceStorageModeShared
+  ];
+
+  metil_object->buffers_vertex[
+    offset_buffer +
+    1
+  ].buffer = [metal_device
+    newBufferWithLength: size_data
     options: MTLResourceStorageModeShared
   ];
 }
@@ -83,6 +127,83 @@ void metil_object_buffers_initialize(
     metil_object,
     metal_device,
     sizeof(struct metil_renderer_data_object)
+  );
+}
+
+void metil_object_buffers_add(
+  struct metil_object* metil_object,
+  id<MTLDevice> metal_device,
+  enum metil_object_buffer_type metil_object_buffer_type
+) {
+  struct metil_object_buffer** buffers = (
+    (void*) 0
+  );
+
+  unsigned char* length_buffers = (
+    (void*) 0
+  );
+
+  switch (
+    metil_object_buffer_type
+  ) {
+    case metil_object_buffer_type_fragment: {
+      buffers = &(
+        metil_object->buffers_fragment
+      );
+
+      length_buffers = &(
+        metil_object->length_buffers_fragment
+      );
+      break;
+    }
+    case metil_object_buffer_type_vertex:
+    default: {
+      buffers = &(
+        metil_object->buffers_vertex
+      );
+
+      length_buffers = &(
+        metil_object->length_buffers_vertex
+      );
+
+      break;
+    }
+  }
+
+  unsigned char index_buffer = (
+    *length_buffers
+  );
+
+  *length_buffers = (
+    *length_buffers +
+    1
+  );
+
+  *buffers = realloc(
+    *buffers,
+    sizeof(
+      struct metil_object_buffer
+    ) *
+    *length_buffers
+  );
+
+  (*buffers)[
+    index_buffer
+  ].buffer = (
+    (void*) 0
+  );
+
+  (*buffers)[
+    index_buffer
+  ].index = (
+    index_buffer +
+    1
+  );
+
+  (*buffers)[
+    index_buffer
+  ].offset = (
+    0
   );
 }
 
@@ -113,7 +234,9 @@ void metil_object_poll(
   struct metil_camera* metil_camera
 ) {
   struct metil_renderer_data_object* data = (
-    metil_object->data.contents
+    metil_object->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
   );
 
   data->position.x = metil_object->position.x;
@@ -140,22 +263,34 @@ void metil_object_destroy(
   struct metil_object* object
 ) {
   if (
-    object->data != (void*)0
-  ) {
-    [object->data release];
-  }
-
-  if (
     object->indices != (void*)0
   ) {
     [object->indices release];
   }
 
-  if (
-    object->vertices != (void*)0
+  for (
+    unsigned char index_buffer_fragment = 0;
+    index_buffer_fragment < object->length_buffers_fragment;
+    ++index_buffer_fragment
   ) {
-    [object->vertices release];
+    [object->buffers_fragment[index_buffer_fragment].buffer release];
   }
+
+  for (
+    unsigned char index_buffer_vertex = 0;
+    index_buffer_vertex < object->length_buffers_vertex;
+    ++index_buffer_vertex
+  ) {
+    [object->buffers_vertex[index_buffer_vertex].buffer release];
+  }
+
+  free(
+    object->buffers_fragment
+  );
+
+  free(
+    object->buffers_vertex
+  );
 
   free(
     object->textures

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -250,7 +250,18 @@ void* metil_renderer_on_initialize_data = (void*)0;
     index_object_fps_display < metil_renderer_length_objects_fps_display;
     ++index_object_fps_display
   ) {
-    [self->objects_fps_display[index_object_fps_display].data release];
+    struct metil_object* metil_object = &(
+      self->objects_fps_display[
+        index_object_fps_display
+      ]
+    );
+
+    [
+      metil_object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer
+      release
+    ];
   }
 
   metil_rendering_properties_destory(
@@ -435,6 +446,22 @@ void* metil_renderer_on_initialize_data = (void*)0;
       ]
     );
 
+    metil_object_buffers_add(
+      &self->objects_fps_display[
+        index_object_fps_display
+      ],
+      self->metal_device,
+      metil_object_buffer_type_vertex
+    );
+
+    metil_object_buffers_add(
+      &self->objects_fps_display[
+        index_object_fps_display
+      ],
+      self->metal_device,
+      metil_object_buffer_type_vertex
+    );
+
     metil_object_texture_add(
       &self->objects_fps_display[
         index_object_fps_display
@@ -458,7 +485,9 @@ void* metil_renderer_on_initialize_data = (void*)0;
 
     self->objects_fps_display[
       index_object_fps_display
-    ].data = [self->metal_device
+    ].buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer = [self->metal_device
       newBufferWithLength: sizeof(struct metil_renderer_data_object)
       options: MTLResourceStorageModeShared
     ];
@@ -469,9 +498,13 @@ void* metil_renderer_on_initialize_data = (void*)0;
       metil_renderer_pipelines_render_index_fps_display
     );
 
-    struct metil_renderer_data_object* data_object = self->objects_fps_display[
-      index_object_fps_display
-    ].data.contents;
+    struct metil_renderer_data_object* data_object = (
+      self->objects_fps_display[
+        index_object_fps_display
+      ].buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
+    );
   }
 }
 
@@ -879,9 +912,25 @@ void* metil_renderer_on_initialize_data = (void*)0;
 
     self->objects_fps_display[
       index_object_fps_display
-    ].vertices = metil_text_characters_default.vertices[
-      char_array_fps[index_object_fps_display]
+    ].buffers_vertex[
+      metil_object_buffer_default_index_vertices
+    ].buffer = metil_text_characters_default.vertices[
+      char_array_fps[
+        index_object_fps_display
+      ]
     ];
+
+    self->objects_fps_display[
+      index_object_fps_display
+    ].buffers_vertex[
+      metil_object_buffer_default_index_vertices
+    ].offset = 0;
+
+    self->objects_fps_display[
+      index_object_fps_display
+    ].buffers_vertex[
+      metil_object_buffer_default_index_vertices
+    ].index = metil_object_buffer_default_index_data;
 
     self->objects_fps_display[
       index_object_fps_display
@@ -1000,12 +1049,14 @@ void* metil_renderer_on_initialize_data = (void*)0;
 }
 
 - (void) render_encode_draw:
-  (id<MTLBuffer>) vertices
+  (struct metil_object_buffer*) buffers_vertex
+  length_buffers_vertex: (unsigned int) length_buffers_vertex
+  buffers_fragment: (struct metil_object_buffer*) buffers_fragment
+  length_buffers_fragment: (unsigned int) length_buffers_fragment
   indices: (id<MTLBuffer>) indices
   length_indices: (unsigned int) length_indices
   textures: (id<MTLTexture>*) textures
   length_textures: (unsigned char) length_textures
-  data: (id<MTLBuffer>) data
   index_pipeline_render: (unsigned short int) index_pipeline_render
   depth_disabled: (unsigned char) depth_disabled
   type_primitive: (MTLPrimitiveType) type_primitive
@@ -1029,6 +1080,14 @@ void* metil_renderer_on_initialize_data = (void*)0;
     ];
   }
 
+  struct metil_object_buffer* buffer_vertex = (
+    (void*) 0
+  );
+
+  struct metil_object_buffer* buffer_fragment = (
+    (void*) 0
+  );
+
   [encoder_render
     setVertexBuffer: self->data_buffer_frame[
       self->index_data_buffer_frame
@@ -1036,6 +1095,50 @@ void* metil_renderer_on_initialize_data = (void*)0;
     offset: 0
     atIndex: metil_renderer_vertex_index_parameter_data_frame
   ];
+
+  for (
+    unsigned char index_buffer_vertex = 0;
+    index_buffer_vertex < length_buffers_vertex;
+    ++index_buffer_vertex
+  ) {
+    buffer_vertex = &(
+      buffers_vertex[
+        index_buffer_vertex
+      ]
+    );
+
+    [encoder_render
+      setVertexBuffer: buffer_vertex->buffer
+      offset: buffer_vertex->offset
+      atIndex: buffer_vertex->index
+    ];
+  }
+
+  [encoder_render
+    setFragmentBuffer: self->data_buffer_frame[
+      self->index_data_buffer_frame
+    ]
+    offset: 0
+    atIndex: metil_renderer_fragment_index_parameter_data_frame
+  ];
+
+  for (
+    unsigned char index_buffer_fragment = 0;
+    index_buffer_fragment < length_buffers_fragment;
+    ++index_buffer_fragment
+  ) {
+    buffer_fragment = &(
+      buffers_fragment[
+        index_buffer_fragment
+      ]
+    );
+
+    [encoder_render
+      setFragmentBuffer: buffer_fragment->buffer
+      offset: buffer_fragment->offset
+      atIndex: buffer_fragment->index
+    ];
+  }
 
   for (
     unsigned char index_texture = 0;
@@ -1051,18 +1154,6 @@ void* metil_renderer_on_initialize_data = (void*)0;
   }
 
   [encoder_render
-    setVertexBuffer: vertices
-    offset: 0
-    atIndex: metil_renderer_vertex_index_parameter_positions
-  ];
-
-  [encoder_render
-    setVertexBuffer: data
-    offset: 0
-    atIndex: metil_renderer_vertex_index_parameter_data_object
-  ];
-
-  [encoder_render
     drawIndexedPrimitives: type_primitive
     indexCount: length_indices
     indexType: type_index
@@ -1076,12 +1167,14 @@ void* metil_renderer_on_initialize_data = (void*)0;
     object->visible == 1
   ) {
     [self
-      render_encode_draw: object->vertices
+      render_encode_draw: object->buffers_vertex
+      length_buffers_vertex: object->length_buffers_vertex
+      buffers_fragment: object->buffers_fragment
+      length_buffers_fragment: object->length_buffers_fragment
       indices: object->indices
       length_indices: object->mesh.length_indices
       textures: object->textures
       length_textures: object->length_textures
-      data: object->data
       index_pipeline_render: object->index_pipeline_render
       depth_disabled: object->depth_disabled
       type_primitive: object->type_primitive
@@ -1095,12 +1188,14 @@ void* metil_renderer_on_initialize_data = (void*)0;
     object->visible == 1
   ) {
     [self
-      render_encode_draw: object->vertices
+      render_encode_draw: object->buffers_vertex
+      length_buffers_vertex: object->length_buffers_vertex
+      buffers_fragment: object->buffers_fragment
+      length_buffers_fragment: object->length_buffers_fragment
       indices: object->indices
       length_indices: object->mesh.length_indices
       textures: (void*)0
       length_textures: 0
-      data: object->data
       index_pipeline_render: metil_renderer_pipelines_render_index_wireframe
       depth_disabled: object->depth_disabled
       type_primitive: MTLPrimitiveTypeLineStrip


### PR DESCRIPTION
- `metil_object_buffer`:implement
- - implement dynamic buffers for object rendering
- - allows for more fine tuned control over data parameters within rendering