### PR TITLE
[enh] Metil meshes add

### DIFF
--- a/examples/2d_rendering/makefile
+++ b/examples/2d_rendering/makefile
@@ -71,8 +71,6 @@ directory_app_contents=${directory_app}/Contents
 directory_app_contents_macos=${directory_app_contents}/MacOS
 directory_app_contents_resources=${directory_app_contents}/Resources
 
-directory_macos_sdk=${shell xcrun --show-sdk-path}
-
 file_metil_metallib=${directory_metil_library}/metil.metallib
 file_metil_storyboard=${directory_metil_library}/metil.storyboardc
 
@@ -90,11 +88,22 @@ files_sources_objc=${shell find ${directory_sources} -name "*.m"}
 files_objects_c=${patsubst ${directory_sources}/%.c,${directory_objects_c}/%.o,${files_sources_c}}
 files_objects_objc=${patsubst ${directory_sources}/%.m,${directory_objects_objc}/%.o,${files_sources_objc}}
 
-target_device=mac
-ifndef target_macos_version
-	target_macos_version=26.1
+ifndef target_device_version
+target_device_version=26.1
 endif
-target_platform=arm64-apple-macos${target_macos_version}
+
+ifndef target_metal_version
+target_metal_version=${target_device_version}
+endif
+
+ifndef target_metal_standard
+target_metal_standard=metal4.0
+endif
+
+target_platform=arm64-apple-macos${target_device_version}
+target_platform_metal=air64-apple-macos${target_metal_version}
+
+directory_sdk=${shell xcrun --sdk macosx${target_device_version} --show-sdk-path}
 
 frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 

--- a/examples/2d_rendering/makefile
+++ b/examples/2d_rendering/makefile
@@ -109,7 +109,7 @@ frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 
 cc=clang
 c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_interrupt_handler_include} -I${directory_metil_include}
-c_flags_platform=-target ${target_platform} -isysroot ${directory_macos_sdk}
+c_flags_platform=-target ${target_platform} -isysroot ${directory_sdk}
 
 c_flags_objc_debug=-O0 -g -v
 c_flags_debug=${c_flags_objc_debug} -da -Q

--- a/examples/3d_rendering/makefile
+++ b/examples/3d_rendering/makefile
@@ -109,7 +109,7 @@ frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 
 cc=clang
 c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_interrupt_handler_include} -I${directory_metil_include}
-c_flags_platform=-target ${target_platform} -isysroot ${directory_macos_sdk}
+c_flags_platform=-target ${target_platform} -isysroot ${directory_sdk}
 
 c_flags_objc_debug=-O0 -g -v
 c_flags_debug=${c_flags_objc_debug} -da -Q

--- a/examples/fog/include/example_fog.h
+++ b/examples/fog/include/example_fog.h
@@ -1,0 +1,16 @@
+#ifndef __example_fog_h
+#define __example_fog_h
+
+#include <metil.h>
+
+int main(
+  int,
+  const char* _Nonnull * _Nonnull
+);
+
+void example_fog_renderer_on_initialize(
+  struct metil* _Nonnull,
+  void* _Nullable
+);
+
+#endif

--- a/examples/fog/include/example_fog_scene.h
+++ b/examples/fog/include/example_fog_scene.h
@@ -1,0 +1,17 @@
+#ifndef __example_fog_scene_h
+#define __example_fog_scene_h
+
+#include <metil.h>
+#include <metil_scenes/metil_scene.h>
+
+void example_fog_scene_initialize(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull
+);
+
+void example_fog_scene_poll(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull
+);
+
+#endif

--- a/examples/fog/makefile
+++ b/examples/fog/makefile
@@ -118,7 +118,7 @@ frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 
 cc=clang
 c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_interrupt_handler_include} -I${directory_metil_include}
-c_flags_platform=-target ${target_platform} -isysroot ${directory_macos_sdk}
+c_flags_platform=-target ${target_platform} -isysroot ${directory_sdk}
 
 c_flags_objc_debug=-O0 -g -v
 c_flags_debug=${c_flags_objc_debug} -da -Q

--- a/examples/fog/makefile
+++ b/examples/fog/makefile
@@ -1,8 +1,10 @@
-name=example_3d_rendering
+name=fog
 
 directory_objects_base=objects
 directory_output_base=output
 
+directory_air=air
+directory_metal=metal
 directory_objects=${directory_objects_base}/release
 
 ifeq (${debug}, 1)
@@ -71,23 +73,6 @@ directory_app_contents=${directory_app}/Contents
 directory_app_contents_macos=${directory_app_contents}/MacOS
 directory_app_contents_resources=${directory_app_contents}/Resources
 
-file_metil_metallib=${directory_metil_library}/metil.metallib
-file_metil_storyboard=${directory_metil_library}/metil.storyboardc
-
-file_info_plist=${directory_metil_plist}/Info.plist
-file_output=${directory_app_contents_macos}/${name}
-file_output_info_plist=${directory_app_contents}/Info.plist
-file_output_metal=${directory_app_contents_resources}/default.metallib
-file_output_storyboard=${directory_app_contents_resources}/metil.storyboardc
-
-files_libraries=${file_cer0_library} ${file_clic3_library} ${file_interrupt_handler_library} ${file_metil_library} ${file_math_c_library}
-
-files_sources_c=${shell find ${directory_sources} -name "*.c"}
-files_sources_objc=${shell find ${directory_sources} -name "*.m"}
-
-files_objects_c=${patsubst ${directory_sources}/%.c,${directory_objects_c}/%.o,${files_sources_c}}
-files_objects_objc=${patsubst ${directory_sources}/%.m,${directory_objects_objc}/%.o,${files_sources_objc}}
-
 ifndef target_device_version
 target_device_version=26.1
 endif
@@ -100,10 +85,34 @@ ifndef target_metal_standard
 target_metal_standard=metal4.0
 endif
 
+
 target_platform=arm64-apple-macos${target_device_version}
 target_platform_metal=air64-apple-macos${target_metal_version}
 
 directory_sdk=${shell xcrun --sdk macosx${target_device_version} --show-sdk-path}
+
+file_metalar_metil_fps_display=${directory_metil_library}/metil_fps_display.metalar
+file_metalar_metil_wireframe=${directory_metil_library}/metil_wireframe.metalar
+
+file_metil_metallib=${directory_metil_library}/metil.metallib
+file_metil_storyboard=${directory_metil_library}/metil.storyboardc
+
+file_info_plist=${directory_metil_plist}/Info.plist
+file_output=${directory_app_contents_macos}/${name}
+file_output_info_plist=${directory_app_contents}/Info.plist
+file_output_metal=${directory_app_contents_resources}/default.metallib
+file_output_storyboard=${directory_app_contents_resources}/metil.storyboardc
+
+files_libraries=${file_cer0_library} ${file_clic3_library} ${file_interrupt_handler_library} ${file_metil_library} ${file_math_c_library}
+
+files_metal=${wildcard ${directory_metal}/*.metal}
+files_air=${patsubst ${directory_metal}/%.metal,${directory_air}/%.air,${files_metal}}
+
+files_sources_c=${shell find ${directory_sources} -name "*.c"}
+files_sources_objc=${shell find ${directory_sources} -name "*.m"}
+
+files_objects_c=${patsubst ${directory_sources}/%.c,${directory_objects_c}/%.o,${files_sources_c}}
+files_objects_objc=${patsubst ${directory_sources}/%.m,${directory_objects_objc}/%.o,${files_sources_objc}}
 
 frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 
@@ -131,6 +140,19 @@ endif
 
 strip=strip
 strip_flags=-x
+
+metal=xcrun -sdk macosx metal
+metal_ar=xcrun -sdk macosx metal-ar
+metallib=xcrun -sdk macosx metallib
+metal_flags_common=-target ${target_platform_metal} -std=${target_metal_standard}
+
+metal_flags=${metal_flags_common} -I${directory_include} -I${directory_metil_include} -I${directory_clic3_include} -isysroot ${directory_sdk}
+
+ifneq (${disable_metal_fast_options}, 1)
+	metal_flags:=${metal_flags} -fmetal-math-mode\=fast -fmetal-math-fp32-functions\=fast
+endif
+
+metal_flags_output=
 
 all: ${name}
 
@@ -161,9 +183,13 @@ else
 endif
 endif
 
-${file_output_metal}: ${file_metil_metallib}
-	mkdir -p ${directory_app_contents_resources}
-	cp ${file_metil_metallib} ${file_output_metal}
+${file_output_metal}: ${files_air}
+	mkdir -p "${dir ${file_output_metal}}"
+	${metallib} ${metal_flags_output} ${files_air} ${file_metalar_metil_wireframe} ${file_metalar_metil_fps_display} -o ${file_output_metal}
+
+${directory_air}/%.air: ${directory_metal}/%.metal
+	mkdir -p "${dir $@}"
+	${metal} ${metal_flags} -c $< -o $@
 
 ${directory_objects_c}/%.o: ${directory_sources}/%.c
 	mkdir -p "${dir $@}"
@@ -183,7 +209,15 @@ ${file_output_info_plist}: ${file_info_plist}
 
 clean_all: clean
 
-clean: clean_objects clean_output
+clean: clean_metal clean_objects clean_output
+
+clean_metal: clean_air clean_metalib
+
+clean_air:
+	-rm -r "${directory_air}" 2> /dev/null
+
+clean_metalib:
+	-rm "${file_output_metal}" 2> /dev/null
 
 clean_objects:
 	-rm -r ${directory_objects_base}

--- a/examples/fog/metal/fog_object.metal
+++ b/examples/fog/metal/fog_object.metal
@@ -1,0 +1,67 @@
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 color;
+};
+
+[[vertex]] struct data_vertex fog_object_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    vertices[id_vertex]
+  );
+
+  data_vertex.color = float4(
+    metal::fmod(
+      data_object->color.x * (float) (
+        id_vertex +
+        1
+      ),
+      1.0f
+    ),
+    metal::fmod(
+      data_object->color.y * (float) (
+        id_vertex +
+        2
+      ),
+      1.0f
+    ),
+    metal::fmod(
+      data_object->color.z * (float) (
+        id_vertex +
+        3
+      ),
+      1.0f
+    ),
+    data_object->color.w
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 fog_object_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return data_vertex.color;
+}

--- a/examples/fog/sources/example_fog.m
+++ b/examples/fog/sources/example_fog.m
@@ -1,0 +1,39 @@
+#include <example_fog.h>
+
+#include <example_fog_scene.h>
+
+#include <metil.h>
+#include <metil_initialize.h>
+#include <metil_library.h>
+#include <metil_scenes/metil_scene_controller.h>
+
+int main(
+  int length_parameters,
+  const char** parameters
+) {
+  return metil_initialize(
+    length_parameters,
+    parameters,
+    "example_fog",
+    example_fog_renderer_on_initialize
+  );
+}
+
+void example_fog_renderer_on_initialize(
+  struct metil* metil,
+  void* data
+) {
+  // metil->rendering_properties.camera.distance_view.far = 100.0f;
+
+  metil_library_initialize(
+    &metil->library,
+    metil->renderer_interface.metal_device,
+    @"fog_object_fragment",
+    @"fog_object_vertex"
+  );
+
+  example_fog_scene_initialize(
+    metil,
+    &metil_scene_controller.scene
+  );
+}

--- a/examples/fog/sources/example_fog_scene.m
+++ b/examples/fog/sources/example_fog_scene.m
@@ -1,0 +1,191 @@
+#include <example_fog_scene.h>
+
+#include <metil.h>
+#include <metil_mesh/metil_mesh_dollop.h>
+#include <metil_mesh/metil_mesh_gem.h>
+#include <metil_mesh/metil_mesh_mushroom.h>
+#include <metil_mesh/metil_mesh_shuttle.h>
+#include <metil_mesh/metil_mesh_tube.h>
+#include <metil_object.h>
+#include <metil_player/metil_player.h>
+#include <metil_rendering/metil_renderable.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_scenes/metil_scene.h>
+
+#include <clic3_vector.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+void example_fog_scene_initialize(
+  struct metil* metil,
+  struct metil_scene* scene
+) {
+  metil_scene_initialize_with_renderables(
+    metil,
+    scene,
+    2000
+  );
+
+  scene->poll = example_fog_scene_poll;
+
+  struct metil_object* object = (
+    (void*)0
+  );
+
+  for (
+    unsigned int index_renderable = 0;
+    index_renderable < scene->length_renderables;
+    ++index_renderable
+  ) {
+    metil_renderable_initialize_at_index(
+      scene->renderables,
+      index_renderable,
+      metil_renderable_type_object
+    );
+
+    object = (
+      scene->renderables[
+        index_renderable
+      ].renderable
+    );
+
+    switch (
+      index_renderable % 5
+    ) {
+      case 0: {
+        metil_mesh_dollop_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 1: {
+        metil_mesh_gem_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 2: {
+        metil_mesh_mushroom_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 3: {
+        metil_mesh_shuttle_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 4: {
+        metil_mesh_tube_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+    }
+
+    metil_object_buffers_initialize(
+      object,
+      metil->renderer_interface.metal_device
+    );
+
+    object->position.x = ((float) (
+      index_renderable % 21 + index_renderable % 32
+    ) / 53.0f - 0.5f) * 1000.0f;
+
+    object->position.y = (
+      object->mesh.size.y +
+      index_renderable % 30
+    );
+
+    object->position.z = ((float) (
+      index_renderable % 34 + index_renderable % 23
+    ) / 57.0f - 0.5f) * 1000.0f;
+
+    object->rotation.x = (
+      (float) index_renderable *
+      34.34f
+    );
+
+    object->rotation.y = (
+      (float) index_renderable *
+      25.34f
+    );
+
+    object->rotation.z = (
+      (float) index_renderable *
+      98.11f
+    );
+
+    struct metil_renderer_data_object* data_object = (
+      object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
+    );
+
+    data_object->color.x = (
+      (float) (index_renderable % 10) / 10.0f
+    );
+
+    data_object->color.y = (
+      (float) ((index_renderable + 3) % 10) / 10.0f
+    );
+
+    data_object->color.z = (
+      (float) ((index_renderable + 5) % 10) / 10.0f
+    );
+
+    data_object->color.w = 1.0f;
+  }
+}
+
+void example_fog_scene_poll(
+  struct metil* metil,
+  struct metil_scene* scene
+) {
+  metil_scene_poll_default(
+    metil,
+    scene
+  );
+}

--- a/include/metil_mesh/metil_mesh_dollop.h
+++ b/include/metil_mesh/metil_mesh_dollop.h
@@ -1,0 +1,14 @@
+#ifndef __metil_mesh_metil_mesh_dollop_h
+#define __metil_mesh_metil_mesh_dollop_h
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+void metil_mesh_dollop_initialize(
+  struct metil_mesh*,
+  struct clic3_vector3_float,
+  struct clic3_vector2_unsigned_short_int
+);
+
+#endif

--- a/include/metil_mesh/metil_mesh_gem.h
+++ b/include/metil_mesh/metil_mesh_gem.h
@@ -1,0 +1,14 @@
+#ifndef __metil_mesh_metil_mesh_gem_h
+#define __metil_mesh_metil_mesh_gem_h
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+void metil_mesh_gem_initialize(
+  struct metil_mesh*,
+  struct clic3_vector3_float,
+  struct clic3_vector2_unsigned_short_int
+);
+
+#endif

--- a/include/metil_mesh/metil_mesh_mushroom.h
+++ b/include/metil_mesh/metil_mesh_mushroom.h
@@ -1,0 +1,14 @@
+#ifndef __metil_mesh_metil_mesh_mushroom_h
+#define __metil_mesh_metil_mesh_mushroom_h
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+void metil_mesh_mushroom_initialize(
+  struct metil_mesh*,
+  struct clic3_vector3_float,
+  struct clic3_vector2_unsigned_short_int
+);
+
+#endif

--- a/include/metil_mesh/metil_mesh_shuttle.h
+++ b/include/metil_mesh/metil_mesh_shuttle.h
@@ -1,0 +1,14 @@
+#ifndef __metil_mesh_metil_mesh_shuttle_h
+#define __metil_mesh_metil_mesh_shuttle_h
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+void metil_mesh_shuttle_initialize(
+  struct metil_mesh*,
+  struct clic3_vector3_float,
+  struct clic3_vector2_unsigned_short_int
+);
+
+#endif

--- a/include/metil_mesh/metil_mesh_tube.h
+++ b/include/metil_mesh/metil_mesh_tube.h
@@ -1,0 +1,14 @@
+#ifndef __metil_mesh_metil_mesh_tube_h
+#define __metil_mesh_metil_mesh_tube_h
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+void metil_mesh_tube_initialize(
+  struct metil_mesh*,
+  struct clic3_vector3_float,
+  struct clic3_vector2_unsigned_short_int
+);
+
+#endif

--- a/sources/metil_mesh/metil_mesh_dollop.c
+++ b/sources/metil_mesh/metil_mesh_dollop.c
@@ -1,0 +1,442 @@
+#include <metil_mesh/metil_mesh_dollop.h>
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+void metil_mesh_dollop_initialize(
+  struct metil_mesh* metil_mesh,
+  struct clic3_vector3_float size,
+  struct clic3_vector2_unsigned_short_int segments
+) {
+  metil_mesh_initialize(
+    metil_mesh
+  );
+
+  struct clic3_vector3_float size_half = {
+    .x = (
+      size.x /
+      2.0f
+    ),
+    .y = (
+      size.y /
+      2.0f
+    ),
+    .z = (
+      size.z /
+      2.0f
+    )
+  };
+
+  metil_mesh->length_vertices = (
+    segments.x *
+    segments.y +
+    2
+  );
+
+  metil_mesh->length_indices = (
+    6 * (
+      segments.x
+    ) + (
+      segments.x * (
+        segments.y -
+        1
+      ) *
+      6
+    )
+  );
+
+   metil_mesh->indices = realloc(
+    metil_mesh->indices,
+    sizeof(unsigned int) *
+    metil_mesh->length_indices
+  );
+
+  metil_mesh->vertices = realloc(
+    metil_mesh->vertices,
+    sizeof(struct clic3_vector4_float) *
+    metil_mesh->length_vertices
+  );
+
+  metil_mesh->vertices[0].x = 0.0f;
+  metil_mesh->vertices[0].y = -size_half.y;
+  metil_mesh->vertices[0].z = 0.0f;
+  metil_mesh->vertices[0].w = 1.0f;
+
+  float increment_y = (
+    size.y / (
+      segments.y +
+      1
+    )
+  );
+
+  unsigned int index_index = (
+    0
+  );
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      0
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_segment_x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      (
+        index_segment_x +
+        1
+      ) %
+      segments.x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+
+  float segment_y_half = (
+    (float) segments.y /
+    2.0f
+  );
+
+  for (
+    unsigned int index_segment_y = 0;
+    index_segment_y < segments.y;
+    ++index_segment_y
+  ) {
+    unsigned int index_vertex_offset_y = (
+      index_segment_y *
+      segments.x
+    );
+
+    float position_y = (
+      increment_y * (
+        index_segment_y +
+        1
+      ) -
+      size_half.y
+    );
+
+    float percentage_radius = (
+      0.0f
+    );
+
+    if (
+      segments.y % 2 == 0
+    ) {
+      if (
+        index_segment_y <= segment_y_half
+      ) {
+        percentage_radius = (
+          (float) index_segment_y /
+          segment_y_half
+        );
+      } else {
+        percentage_radius = (
+          (
+            segments.y -
+            (float) index_segment_y
+          ) /
+          segment_y_half
+        );
+      }
+    } else {
+    }
+
+    percentage_radius = (
+      sin(
+        percentage_radius *
+        M_PI /
+        2.0f
+      )
+    );
+
+    struct clic3_vector2_float radius = {
+      .x = (
+        size_half.x *
+        percentage_radius
+      ),
+      .y = (
+        size_half.z *
+        percentage_radius
+      )
+    };
+
+    for (
+      unsigned int index_segment_x = 0;
+      index_segment_x < segments.x;
+      ++index_segment_x
+    ) {
+      unsigned int index_vertex = (
+        index_vertex_offset_y +
+        index_segment_x +
+        1
+      );
+
+      float angle = (
+        (float) index_segment_x /
+        (float) segments.x *
+        M_PI * 2.0f
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].x = (
+        sin(angle) *
+        radius.x
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].y = (
+        position_y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].z = (
+        cos(angle) *
+        radius.y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].w = (
+        1.0f
+      );
+
+      if (
+        index_segment_y == (
+          segments.y -
+          1
+        )
+      ) {
+        continue;
+      }
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+      }
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index 
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      }
+    }
+  }
+
+  unsigned int index_vertex_last = (
+    metil_mesh->length_vertices -
+    1
+  );
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].x = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].y = size_half.y;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].z = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].w = 1.0f;
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last -
+      index_segment_x -
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    if (
+      index_segment_x == (
+        segments.x -
+        1
+      )
+    ) {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        1
+      );
+    } else {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        index_segment_x -
+        2
+      );
+    }
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+}

--- a/sources/metil_mesh/metil_mesh_gem.c
+++ b/sources/metil_mesh/metil_mesh_gem.c
@@ -1,0 +1,434 @@
+#include <metil_mesh/metil_mesh_gem.h>
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+void metil_mesh_gem_initialize(
+  struct metil_mesh* metil_mesh,
+  struct clic3_vector3_float size,
+  struct clic3_vector2_unsigned_short_int segments
+) {
+  metil_mesh_initialize(
+    metil_mesh
+  );
+
+  struct clic3_vector3_float size_half = {
+    .x = (
+      size.x /
+      2.0f
+    ),
+    .y = (
+      size.y /
+      2.0f
+    ),
+    .z = (
+      size.z /
+      2.0f
+    )
+  };
+
+  metil_mesh->length_vertices = (
+    segments.x *
+    segments.y +
+    2
+  );
+
+  metil_mesh->length_indices = (
+    6 * (
+      segments.x
+    ) + (
+      segments.x * (
+        segments.y -
+        1
+      ) *
+      6
+    )
+  );
+
+   metil_mesh->indices = realloc(
+    metil_mesh->indices,
+    sizeof(unsigned int) *
+    metil_mesh->length_indices
+  );
+
+  metil_mesh->vertices = realloc(
+    metil_mesh->vertices,
+    sizeof(struct clic3_vector4_float) *
+    metil_mesh->length_vertices
+  );
+
+  metil_mesh->vertices[0].x = 0.0f;
+  metil_mesh->vertices[0].y = -size_half.y;
+  metil_mesh->vertices[0].z = 0.0f;
+  metil_mesh->vertices[0].w = 1.0f;
+
+  float increment_y = (
+    size.y / (
+      segments.y +
+      1
+    )
+  );
+
+  unsigned int index_index = (
+    0
+  );
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      0
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_segment_x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      (
+        index_segment_x +
+        1
+      ) %
+      segments.x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+
+  float segment_y_half = (
+    (float) segments.y /
+    2.0f
+  );
+
+  for (
+    unsigned int index_segment_y = 0;
+    index_segment_y < segments.y;
+    ++index_segment_y
+  ) {
+    unsigned int index_vertex_offset_y = (
+      index_segment_y *
+      segments.x
+    );
+
+    float position_y = (
+      increment_y * (
+        index_segment_y +
+        1
+      ) -
+      size_half.y
+    );
+
+    float percentage_radius = (
+      0.0f
+    );
+
+    if (
+      segments.y % 2 == 0
+    ) {
+      if (
+        index_segment_y <= segment_y_half
+      ) {
+        percentage_radius = (
+          (float) index_segment_y /
+          segment_y_half
+        );
+      } else {
+        percentage_radius = (
+          (
+            segments.y -
+            (float) index_segment_y
+          ) /
+          segment_y_half
+        );
+      }
+    } else {
+    }
+
+    struct clic3_vector2_float radius = {
+      .x = (
+        size_half.x *
+        percentage_radius
+      ),
+      .y = (
+        size_half.z *
+        percentage_radius
+      )
+    };
+
+    for (
+      unsigned int index_segment_x = 0;
+      index_segment_x < segments.x;
+      ++index_segment_x
+    ) {
+      unsigned int index_vertex = (
+        index_vertex_offset_y +
+        index_segment_x +
+        1
+      );
+
+      float angle = (
+        (float) index_segment_x /
+        (float) segments.x *
+        M_PI * 2.0f
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].x = (
+        sin(angle) *
+        radius.x
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].y = (
+        position_y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].z = (
+        cos(angle) *
+        radius.y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].w = (
+        1.0f
+      );
+
+      if (
+        index_segment_y == (
+          segments.y -
+          1
+        )
+      ) {
+        continue;
+      }
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+      }
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index 
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      }
+    }
+  }
+
+  unsigned int index_vertex_last = (
+    metil_mesh->length_vertices -
+    1
+  );
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].x = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].y = size_half.y;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].z = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].w = 1.0f;
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last -
+      index_segment_x -
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    if (
+      index_segment_x == (
+        segments.x -
+        1
+      )
+    ) {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        1
+      );
+    } else {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        index_segment_x -
+        2
+      );
+    }
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+}

--- a/sources/metil_mesh/metil_mesh_mushroom.c
+++ b/sources/metil_mesh/metil_mesh_mushroom.c
@@ -1,0 +1,414 @@
+#include <metil_mesh/metil_mesh_mushroom.h>
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+void metil_mesh_mushroom_initialize(
+  struct metil_mesh* metil_mesh,
+  struct clic3_vector3_float size,
+  struct clic3_vector2_unsigned_short_int segments
+) {
+  metil_mesh_initialize(
+    metil_mesh
+  );
+
+  struct clic3_vector3_float size_half = {
+    .x = (
+      size.x /
+      2.0f
+    ),
+    .y = (
+      size.y /
+      2.0f
+    ),
+    .z = (
+      size.z /
+      2.0f
+    )
+  };
+
+  metil_mesh->length_vertices = (
+    segments.x *
+    segments.y +
+    2
+  );
+
+  metil_mesh->length_indices = (
+    6 * (
+      segments.x
+    ) + (
+      segments.x * (
+        segments.y -
+        1
+      ) *
+      6
+    )
+  );
+
+   metil_mesh->indices = realloc(
+    metil_mesh->indices,
+    sizeof(unsigned int) *
+    metil_mesh->length_indices
+  );
+
+  metil_mesh->vertices = realloc(
+    metil_mesh->vertices,
+    sizeof(struct clic3_vector4_float) *
+    metil_mesh->length_vertices
+  );
+
+  metil_mesh->vertices[0].x = 0.0f;
+  metil_mesh->vertices[0].y = -size_half.y;
+  metil_mesh->vertices[0].z = 0.0f;
+  metil_mesh->vertices[0].w = 1.0f;
+
+  float increment_y = (
+    size.y / (
+      segments.y +
+      1
+    )
+  );
+
+  unsigned int index_index = (
+    0
+  );
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      0
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_segment_x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      (
+        index_segment_x +
+        1
+      ) %
+      segments.x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+
+  for (
+    unsigned int index_segment_y = 0;
+    index_segment_y < segments.y;
+    ++index_segment_y
+  ) {
+    unsigned int index_vertex_offset_y = (
+      index_segment_y *
+      segments.x
+    );
+
+    float position_y = (
+      increment_y * (
+        index_segment_y +
+        1
+      ) -
+      size_half.y
+    );
+
+    float percentage_radius = (
+      (float) (
+        (
+          index_segment_y +
+          segments.y / 2
+        ) %
+        segments.y
+      ) /
+      (float) segments.y
+    );    
+
+    struct clic3_vector2_float radius = {
+      .x = (
+        size_half.x *
+        percentage_radius
+      ),
+      .y = (
+        size_half.z *
+        percentage_radius
+      )
+    };
+
+    for (
+      unsigned int index_segment_x = 0;
+      index_segment_x < segments.x;
+      ++index_segment_x
+    ) {
+      unsigned int index_vertex = (
+        index_vertex_offset_y +
+        index_segment_x +
+        1
+      );
+
+      float angle = (
+        (float) index_segment_x /
+        (float) segments.x *
+        M_PI * 2.0f
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].x = (
+        sin(angle) *
+        radius.x
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].y = (
+        position_y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].z = (
+        cos(angle) *
+        radius.y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].w = (
+        1.0f
+      );
+
+      if (
+        index_segment_y == (
+          segments.y -
+          1
+        )
+      ) {
+        continue;
+      }
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+      }
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index 
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      }
+    }
+  }
+
+  unsigned int index_vertex_last = (
+    metil_mesh->length_vertices -
+    1
+  );
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].x = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].y = size_half.y;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].z = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].w = 1.0f;
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last -
+      index_segment_x -
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    if (
+      index_segment_x == (
+        segments.x -
+        1
+      )
+    ) {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        1
+      );
+    } else {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        index_segment_x -
+        2
+      );
+    }
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+}

--- a/sources/metil_mesh/metil_mesh_shuttle.c
+++ b/sources/metil_mesh/metil_mesh_shuttle.c
@@ -1,0 +1,386 @@
+#include <metil_mesh/metil_mesh_shuttle.h>
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+void metil_mesh_shuttle_initialize(
+  struct metil_mesh* metil_mesh,
+  struct clic3_vector3_float size,
+  struct clic3_vector2_unsigned_short_int segments
+) {
+  metil_mesh_initialize(
+    metil_mesh
+  );
+
+  struct clic3_vector3_float size_half = {
+    .x = (
+      size.x /
+      2.0f
+    ),
+    .y = (
+      size.y /
+      2.0f
+    ),
+    .z = (
+      size.z /
+      2.0f
+    )
+  };
+
+  metil_mesh->length_vertices = (
+    segments.x *
+    segments.y +
+    2
+  );
+
+  metil_mesh->length_indices = (
+    6 * (
+      segments.x
+    ) + (
+      segments.x * (
+        segments.y -
+        1
+      ) *
+      6
+    )
+  );
+
+   metil_mesh->indices = realloc(
+    metil_mesh->indices,
+    sizeof(unsigned int) *
+    metil_mesh->length_indices
+  );
+
+  metil_mesh->vertices = realloc(
+    metil_mesh->vertices,
+    sizeof(struct clic3_vector4_float) *
+    metil_mesh->length_vertices
+  );
+
+  metil_mesh->vertices[0].x = 0.0f;
+  metil_mesh->vertices[0].y = -size_half.y;
+  metil_mesh->vertices[0].z = 0.0f;
+  metil_mesh->vertices[0].w = 1.0f;
+
+  float increment_y = (
+    size.y /
+    segments.y
+  );
+
+  unsigned int index_index = (
+    0
+  );
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      0
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_segment_x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      (
+        index_segment_x +
+        1
+      ) %
+      segments.x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+
+  for (
+    unsigned int index_segment_y = 0;
+    index_segment_y < segments.y;
+    ++index_segment_y
+  ) {
+    unsigned int index_vertex_offset_y = (
+      index_segment_y *
+      segments.x
+    );
+
+    float position_y = (
+      increment_y * (
+        index_segment_y +
+        1
+      )
+    );
+
+    for (
+      unsigned int index_segment_x = 0;
+      index_segment_x < segments.x;
+      ++index_segment_x
+    ) {
+      unsigned int index_vertex = (
+        index_vertex_offset_y +
+        index_segment_x +
+        1
+      );
+
+      float angle = (
+        (float) index_segment_x /
+        (float) segments.x *
+        M_PI * 2.0f
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].x = (
+        sin(angle) *
+        size_half.x
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].y = (
+        position_y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].z = (
+        cos(angle) *
+        size_half.z
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].w = (
+        1.0f
+      );
+
+      if (
+        index_segment_y == (
+          segments.y -
+          1
+        )
+      ) {
+        continue;
+      }
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+      }
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      }
+    }
+  }
+
+  unsigned int index_vertex_last = (
+    metil_mesh->length_vertices -
+    1
+  );
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].x = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].y = size_half.y;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].z = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].w = 1.0f;
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last - (
+        index_segment_x +
+        1
+      )
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      (
+        index_vertex_last - (
+          (
+            index_segment_x +
+            1
+          ) % (
+            segments.x 
+          ) +
+          1
+        )
+      ) % (
+        segments.x +
+        1
+      )
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+}

--- a/sources/metil_mesh/metil_mesh_tube.c
+++ b/sources/metil_mesh/metil_mesh_tube.c
@@ -1,0 +1,391 @@
+#include <metil_mesh/metil_mesh_tube.h>
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_vector.h>
+
+#include <math.h>
+#include <stdlib.h>
+
+void metil_mesh_tube_initialize(
+  struct metil_mesh* metil_mesh,
+  struct clic3_vector3_float size,
+  struct clic3_vector2_unsigned_short_int segments
+) {
+  metil_mesh_initialize(
+    metil_mesh
+  );
+
+  struct clic3_vector3_float size_half = {
+    .x = (
+      size.x /
+      2.0f
+    ),
+    .y = (
+      size.y /
+      2.0f
+    ),
+    .z = (
+      size.z /
+      2.0f
+    )
+  };
+
+  metil_mesh->length_vertices = (
+    segments.x *
+    segments.y +
+    2
+  );
+
+  metil_mesh->length_indices = (
+    6 * (
+      segments.x
+    ) + (
+      segments.x * (
+        segments.y -
+        1
+      ) *
+      6
+    )
+  );
+
+   metil_mesh->indices = realloc(
+    metil_mesh->indices,
+    sizeof(unsigned int) *
+    metil_mesh->length_indices
+  );
+
+  metil_mesh->vertices = realloc(
+    metil_mesh->vertices,
+    sizeof(struct clic3_vector4_float) *
+    metil_mesh->length_vertices
+  );
+
+  metil_mesh->vertices[0].x = 0.0f;
+  metil_mesh->vertices[0].y = -size_half.y;
+  metil_mesh->vertices[0].z = 0.0f;
+  metil_mesh->vertices[0].w = 1.0f;
+
+  float increment_y = (
+    size.y / (
+      segments.y -
+      1
+    )
+  );
+
+  unsigned int index_index = (
+    0
+  );
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      0
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_segment_x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      (
+        index_segment_x +
+        1
+      ) %
+      segments.x +
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+
+  for (
+    unsigned int index_segment_y = 0;
+    index_segment_y < segments.y;
+    ++index_segment_y
+  ) {
+    unsigned int index_vertex_offset_y = (
+      index_segment_y *
+      segments.x
+    );
+
+    float position_y = (
+      increment_y * (
+        index_segment_y
+      ) -
+      size_half.y
+    );
+
+    for (
+      unsigned int index_segment_x = 0;
+      index_segment_x < segments.x;
+      ++index_segment_x
+    ) {
+      unsigned int index_vertex = (
+        index_vertex_offset_y +
+        index_segment_x +
+        1
+      );
+
+      float angle = (
+        (float) index_segment_x /
+        (float) segments.x *
+        M_PI * 2.0f
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].x = (
+        sin(angle) *
+        size_half.x
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].y = (
+        position_y
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].z = (
+        cos(angle) *
+        size_half.z
+      );
+
+      metil_mesh->vertices[
+        index_vertex
+      ].w = (
+        1.0f
+      );
+
+      if (
+        index_segment_y == (
+          segments.y -
+          1
+        )
+      ) {
+        continue;
+      }
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+      }
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh->indices[
+        index_index 
+      ] = (
+        index_vertex +
+        segments.x
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      if (
+        index_segment_x == (
+          segments.x -
+          1
+        )
+      ) {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex_offset_y +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      } else {
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+
+        metil_mesh->indices[
+          index_index
+        ] = (
+          index_vertex +
+          segments.x +
+          1
+        );
+
+        index_index = (
+          index_index +
+          1
+        );
+      }
+    }
+  }
+
+  unsigned int index_vertex_last = (
+    metil_mesh->length_vertices -
+    1
+  );
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].x = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].y = size_half.y;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].z = 0.0f;
+
+  metil_mesh->vertices[
+    index_vertex_last
+  ].w = 1.0f;
+
+  for (
+    unsigned int index_segment_x = 0;
+    index_segment_x < segments.x;
+    ++index_segment_x
+  ) {
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    metil_mesh->indices[
+      index_index
+    ] = (
+      index_vertex_last -
+      index_segment_x -
+      1
+    );
+
+    index_index = (
+      index_index +
+      1
+    );
+
+    if (
+      index_segment_x == (
+        segments.x -
+        1
+      )
+    ) {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        1
+      );
+    } else {
+      metil_mesh->indices[
+        index_index
+      ] = (
+        index_vertex_last -
+        index_segment_x -
+        2
+      );
+    }
+
+    index_index = (
+      index_index +
+      1
+    );
+  }
+}


### PR DESCRIPTION
This adds more meshes.

`examples/fog` will eventually be used for fog. I'm implementing fog. In another pull request, there will be fog.

For now, have some meshes.

https://github.com/user-attachments/assets/c04cd449-3090-4f9e-8866-783aad7fa6f4

a fourth of a second of full resolution is 10mb, so 480p

<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 38 51" src="https://github.com/user-attachments/assets/a7a68b74-428d-41e0-a062-ebd913c7a707" />
<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 39 02" src="https://github.com/user-attachments/assets/84adca04-6111-4375-91f1-24639b7c19a9" />
<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 39 14" src="https://github.com/user-attachments/assets/15c054b9-9315-44b4-a94a-410f5ded093c" />
<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 39 29" src="https://github.com/user-attachments/assets/b646ea52-5f86-482c-a1e1-81e1efcb7390" />

and just for fun here's 10000 meshes/renderables

<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 40 06" src="https://github.com/user-attachments/assets/47a58607-5d52-47ed-acf9-eee306f83611" />


and 20000 meshes/renderables
<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 41 40" src="https://github.com/user-attachments/assets/44d2e37c-b603-4c9b-9960-ca9d2e1fc3a8" />
<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 41 47" src="https://github.com/user-attachments/assets/b844803d-d91d-432d-939f-e852091afdca" />

<img width="1966" height="1250" alt="Screenshot 2025-12-31 at 04 41 32" src="https://github.com/user-attachments/assets/5c8e6d7e-586a-4d41-a61a-b85c5e6cccb9" />




