### PR TITLE
[bug|enh] Metil fog

### DIFF
--- a/examples/fog/include/example_fog_pipeline_index.h
+++ b/examples/fog/include/example_fog_pipeline_index.h
@@ -1,0 +1,6 @@
+#ifndef __example_fog_pipeline_index_h
+#define __example_fog_pipeline_index_h
+
+extern unsigned short int example_face_pipeline_index_fog;
+
+#endif

--- a/examples/fog/include/example_fog_values.h
+++ b/examples/fog/include/example_fog_values.h
@@ -1,0 +1,18 @@
+#ifndef __example_fog_values_h
+#define __example_fog_values_h
+
+#define fog_thickness_minimum 0.0f
+#define fog_thickness_maximum 0.7f
+#define fog_thickness_range (\
+  fog_thickness_maximum -\
+  fog_thickness_minimum\
+)
+
+#define fog_distance_minimum 300.0f
+#define fog_distance_maximum 700.0f
+#define fog_distance_range (\
+  fog_distance_maximum -\
+  fog_distance_minimum\
+)
+
+#endif

--- a/examples/fog/metal/fog.metal
+++ b/examples/fog/metal/fog.metal
@@ -1,0 +1,59 @@
+#include <example_fog_values.h>
+
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 color;
+  float brightness;
+};
+
+[[vertex]] struct data_vertex fog_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    vertices[id_vertex]
+  );
+
+  data_vertex.color = float4(
+    data_object->color.x,
+    data_object->color.y,
+    data_object->color.z,
+    data_object->color.w
+  );
+
+  data_vertex.brightness = data_frame->brightness;
+
+  return data_vertex;
+}
+
+[[fragment]] float4 fog_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return float4(
+    data_vertex.color.r * data_vertex.brightness,
+    data_vertex.color.g * data_vertex.brightness,
+    data_vertex.color.b * data_vertex.brightness,
+    data_vertex.color.a
+  );
+}

--- a/examples/fog/metal/fog_object.metal
+++ b/examples/fog/metal/fog_object.metal
@@ -1,3 +1,5 @@
+#include <example_fog_values.h>
+
 #include <metil_rendering/metil_renderer_data_frame.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_rendering/metil_renderer_vertex_index_parameter.h>
@@ -6,6 +8,7 @@ struct data_vertex {
   float4 position [[position]];
   float4 color;
   float brightness;
+  float distance;
 };
 
 [[vertex]] struct data_vertex fog_object_vertex(
@@ -37,21 +40,21 @@ struct data_vertex {
     metal::fmod(
       data_object->color.x * (float) (
         id_vertex +
-        1
+        4234.23842398
       ),
       1.0f
     ),
     metal::fmod(
       data_object->color.y * (float) (
         id_vertex +
-        2
+        1489.8924489
       ),
       1.0f
     ),
     metal::fmod(
       data_object->color.z * (float) (
         id_vertex +
-        3
+        1.3892810472
       ),
       1.0f
     ),
@@ -63,16 +66,90 @@ struct data_vertex {
     (data_object->size.z)
   );
 
+  data_vertex.distance = (
+    metal::distance(
+      float3(
+        data_frame->position_player.x,
+        data_frame->position_player.y,
+        data_frame->position_player.z
+      ),
+      float3(
+        data_object->position.x,
+        data_object->position.y,
+        data_object->position.z
+      )
+    )
+  );
+
   return data_vertex;
+}
+
+float4 fog_apply(
+  float4 color,
+  float distance
+) {
+  float distance_offset = metal::fmin(
+    metal::fmax(
+      (
+        distance -
+        fog_distance_minimum
+      ),
+      0.0f
+    ),
+    fog_distance_maximum
+  );
+
+  float distance_percentage = (
+    distance_offset /
+    fog_distance_maximum
+  );
+
+  float fog_thickness = (
+    distance_percentage *
+    fog_thickness_range +
+    fog_thickness_minimum
+  );
+
+  return float4(
+    metal::fmin(
+      (
+        color.r +
+        fog_thickness
+      ),
+      1.0f
+    ),
+    metal::fmin(
+      (
+        color.g +
+        fog_thickness
+      ),
+      1.0f
+    ),
+    metal::fmin(
+      (
+        color.b +
+        fog_thickness
+      ),
+      1.0f
+    ),
+    color.a
+  );
 }
 
 [[fragment]] float4 fog_object_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return float4(
+  float4 color_lighted = float4(
     data_vertex.color.r * data_vertex.brightness,
     data_vertex.color.g * data_vertex.brightness,
     data_vertex.color.b * data_vertex.brightness,
     data_vertex.color.a
   );
+
+  float4 color_fogged = fog_apply(
+    color_lighted,
+    data_vertex.distance
+  );
+
+  return color_fogged;
 }

--- a/examples/fog/metal/fog_object.metal
+++ b/examples/fog/metal/fog_object.metal
@@ -5,6 +5,7 @@
 struct data_vertex {
   float4 position [[position]];
   float4 color;
+  float brightness;
 };
 
 [[vertex]] struct data_vertex fog_object_vertex(
@@ -57,11 +58,21 @@ struct data_vertex {
     data_object->color.w
   );
 
+  data_vertex.brightness = (
+    (vertices[id_vertex].z + data_object->size.z / 2.0f) /
+    (data_object->size.z)
+  );
+
   return data_vertex;
 }
 
 [[fragment]] float4 fog_object_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return float4(
+    data_vertex.color.r * data_vertex.brightness,
+    data_vertex.color.g * data_vertex.brightness,
+    data_vertex.color.b * data_vertex.brightness,
+    data_vertex.color.a
+  );
 }

--- a/examples/fog/sources/example_fog.m
+++ b/examples/fog/sources/example_fog.m
@@ -1,6 +1,7 @@
 #include <example_fog.h>
 
 #include <example_fog_scene.h>
+#include <example_fog_pipeline_index.h>
 
 #include <metil.h>
 #include <metil_initialize.h>
@@ -24,15 +25,24 @@ void example_fog_renderer_on_initialize(
   void* data
 ) {
 
-  metil->rendering_properties.mode = metil_rendering_properties_mode_wireframe;
-  // metil->rendering_properties.camera.distance_view.far = 100.0f;
-
   metil_library_initialize(
     &metil->library,
     metil->renderer_interface.metal_device,
     @"fog_object_fragment",
     @"fog_object_vertex"
   );
+
+  example_face_pipeline_index_fog = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"fog_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"fog_vertex"
+    ]
+  ];
 
   example_fog_scene_initialize(
     metil,

--- a/examples/fog/sources/example_fog.m
+++ b/examples/fog/sources/example_fog.m
@@ -23,6 +23,8 @@ void example_fog_renderer_on_initialize(
   struct metil* metil,
   void* data
 ) {
+
+  metil->rendering_properties.mode = metil_rendering_properties_mode_wireframe;
   // metil->rendering_properties.camera.distance_view.far = 100.0f;
 
   metil_library_initialize(

--- a/examples/fog/sources/example_fog_pipeline_index.c
+++ b/examples/fog/sources/example_fog_pipeline_index.c
@@ -1,0 +1,3 @@
+#include <example_fog_pipeline_index.h>
+
+unsigned short int example_face_pipeline_index_fog = 0;

--- a/examples/fog/sources/example_fog_scene.m
+++ b/examples/fog/sources/example_fog_scene.m
@@ -1,6 +1,7 @@
 #include <example_fog_scene.h>
 
 #include <metil.h>
+#include <metil_mesh/metil_mesh_ball.h>
 #include <metil_mesh/metil_mesh_dollop.h>
 #include <metil_mesh/metil_mesh_gem.h>
 #include <metil_mesh/metil_mesh_mushroom.h>
@@ -24,7 +25,7 @@ void example_fog_scene_initialize(
   metil_scene_initialize_with_renderables(
     metil,
     scene,
-    2000
+    200
   );
 
   scene->poll = example_fog_scene_poll;
@@ -50,80 +51,93 @@ void example_fog_scene_initialize(
       ].renderable
     );
 
-    switch (
-      index_renderable % 5
-    ) {
-      case 0: {
-        metil_mesh_dollop_initialize(
-          &object->mesh,
-          (struct clic3_vector3_float) {
-            .x = 10.0f,
-            .y = 10.0f,
-            .z = 10.0f
-          }, (struct clic3_vector2_unsigned_short_int) {
-            .x = 10,
-            .y = 10
-          }
-        );
-        break;
+    metil_mesh_ball_initialize(
+      &object->mesh,
+      2.0f * ((index_renderable * 3) % 10),
+      (struct clic3_vector2_unsigned_short_int) {
+        .x = 10 + (
+          index_renderable % 2
+        ),
+        .y = 10 + (
+          index_renderable % 3 == 0 ? 1 : 0
+        )
       }
-      case 1: {
-        metil_mesh_gem_initialize(
-          &object->mesh,
-          (struct clic3_vector3_float) {
-            .x = 10.0f,
-            .y = 10.0f,
-            .z = 10.0f
-          }, (struct clic3_vector2_unsigned_short_int) {
-            .x = 10,
-            .y = 10
-          }
-        );
-        break;
-      }
-      case 2: {
-        metil_mesh_mushroom_initialize(
-          &object->mesh,
-          (struct clic3_vector3_float) {
-            .x = 10.0f,
-            .y = 10.0f,
-            .z = 10.0f
-          }, (struct clic3_vector2_unsigned_short_int) {
-            .x = 10,
-            .y = 10
-          }
-        );
-        break;
-      }
-      case 3: {
-        metil_mesh_shuttle_initialize(
-          &object->mesh,
-          (struct clic3_vector3_float) {
-            .x = 10.0f,
-            .y = 10.0f,
-            .z = 10.0f
-          }, (struct clic3_vector2_unsigned_short_int) {
-            .x = 10,
-            .y = 10
-          }
-        );
-        break;
-      }
-      case 4: {
-        metil_mesh_tube_initialize(
-          &object->mesh,
-          (struct clic3_vector3_float) {
-            .x = 10.0f,
-            .y = 10.0f,
-            .z = 10.0f
-          }, (struct clic3_vector2_unsigned_short_int) {
-            .x = 10,
-            .y = 10
-          }
-        );
-        break;
-      }
-    }
+    );
+
+    // switch (
+    //   index_renderable % 5
+    // ) {
+    //   case 0: {
+    //     metil_mesh_dollop_initialize(
+    //       &object->mesh,
+    //       (struct clic3_vector3_float) {
+    //         .x = 10.0f,
+    //         .y = 10.0f,
+    //         .z = 10.0f
+    //       }, (struct clic3_vector2_unsigned_short_int) {
+    //         .x = 10,
+    //         .y = 10
+    //       }
+    //     );
+    //     break;
+    //   }
+    //   case 1: {
+    //     metil_mesh_gem_initialize(
+    //       &object->mesh,
+    //       (struct clic3_vector3_float) {
+    //         .x = 10.0f,
+    //         .y = 10.0f,
+    //         .z = 10.0f
+    //       }, (struct clic3_vector2_unsigned_short_int) {
+    //         .x = 10,
+    //         .y = 10
+    //       }
+    //     );
+    //     break;
+    //   }
+    //   case 2: {
+    //     metil_mesh_mushroom_initialize(
+    //       &object->mesh,
+    //       (struct clic3_vector3_float) {
+    //         .x = 10.0f,
+    //         .y = 10.0f,
+    //         .z = 10.0f
+    //       }, (struct clic3_vector2_unsigned_short_int) {
+    //         .x = 10,
+    //         .y = 10
+    //       }
+    //     );
+    //     break;
+    //   }
+    //   case 3: {
+    //     metil_mesh_shuttle_initialize(
+    //       &object->mesh,
+    //       (struct clic3_vector3_float) {
+    //         .x = 10.0f,
+    //         .y = 10.0f,
+    //         .z = 10.0f
+    //       }, (struct clic3_vector2_unsigned_short_int) {
+    //         .x = 10,
+    //         .y = 10
+    //       }
+    //     );
+    //     break;
+    //   }
+    //   case 4: {
+    //     metil_mesh_tube_initialize(
+    //       &object->mesh,
+    //       (struct clic3_vector3_float) {
+    //         .x = 10.0f,
+    //         .y = 10.0f,
+    //         .z = 10.0f
+    //       }, (struct clic3_vector2_unsigned_short_int) {
+    //         .x = 10,
+    //         .y = 10
+    //       }
+    //     );
+    //     break;
+    //   }
+    // }
 
     metil_object_buffers_initialize(
       object,

--- a/examples/fog/sources/example_fog_scene.m
+++ b/examples/fog/sources/example_fog_scene.m
@@ -1,5 +1,8 @@
 #include <example_fog_scene.h>
 
+#include <example_fog_pipeline_index.h>
+#include <example_fog_values.h>
+
 #include <metil.h>
 #include <metil_mesh/metil_mesh_ball.h>
 #include <metil_mesh/metil_mesh_dollop.h>
@@ -25,7 +28,7 @@ void example_fog_scene_initialize(
   metil_scene_initialize_with_renderables(
     metil,
     scene,
-    200
+    2000
   );
 
   scene->poll = example_fog_scene_poll;
@@ -35,7 +38,7 @@ void example_fog_scene_initialize(
   );
 
   for (
-    unsigned int index_renderable = 0;
+    unsigned int index_renderable = 1;
     index_renderable < scene->length_renderables;
     ++index_renderable
   ) {
@@ -51,93 +54,95 @@ void example_fog_scene_initialize(
       ].renderable
     );
 
-    metil_mesh_ball_initialize(
-      &object->mesh,
-      2.0f * ((index_renderable * 3) % 10),
-      (struct clic3_vector2_unsigned_short_int) {
-        .x = 10 + (
-          index_renderable % 2
-        ),
-        .y = 10 + (
-          index_renderable % 3 == 0 ? 1 : 0
-        )
+    switch (
+      index_renderable % 6
+    ) {
+      case 0: {
+        metil_mesh_dollop_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
       }
-    );
-
-    // switch (
-    //   index_renderable % 5
-    // ) {
-    //   case 0: {
-    //     metil_mesh_dollop_initialize(
-    //       &object->mesh,
-    //       (struct clic3_vector3_float) {
-    //         .x = 10.0f,
-    //         .y = 10.0f,
-    //         .z = 10.0f
-    //       }, (struct clic3_vector2_unsigned_short_int) {
-    //         .x = 10,
-    //         .y = 10
-    //       }
-    //     );
-    //     break;
-    //   }
-    //   case 1: {
-    //     metil_mesh_gem_initialize(
-    //       &object->mesh,
-    //       (struct clic3_vector3_float) {
-    //         .x = 10.0f,
-    //         .y = 10.0f,
-    //         .z = 10.0f
-    //       }, (struct clic3_vector2_unsigned_short_int) {
-    //         .x = 10,
-    //         .y = 10
-    //       }
-    //     );
-    //     break;
-    //   }
-    //   case 2: {
-    //     metil_mesh_mushroom_initialize(
-    //       &object->mesh,
-    //       (struct clic3_vector3_float) {
-    //         .x = 10.0f,
-    //         .y = 10.0f,
-    //         .z = 10.0f
-    //       }, (struct clic3_vector2_unsigned_short_int) {
-    //         .x = 10,
-    //         .y = 10
-    //       }
-    //     );
-    //     break;
-    //   }
-    //   case 3: {
-    //     metil_mesh_shuttle_initialize(
-    //       &object->mesh,
-    //       (struct clic3_vector3_float) {
-    //         .x = 10.0f,
-    //         .y = 10.0f,
-    //         .z = 10.0f
-    //       }, (struct clic3_vector2_unsigned_short_int) {
-    //         .x = 10,
-    //         .y = 10
-    //       }
-    //     );
-    //     break;
-    //   }
-    //   case 4: {
-    //     metil_mesh_tube_initialize(
-    //       &object->mesh,
-    //       (struct clic3_vector3_float) {
-    //         .x = 10.0f,
-    //         .y = 10.0f,
-    //         .z = 10.0f
-    //       }, (struct clic3_vector2_unsigned_short_int) {
-    //         .x = 10,
-    //         .y = 10
-    //       }
-    //     );
-    //     break;
-    //   }
-    // }
+      case 1: {
+        metil_mesh_gem_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 2: {
+        metil_mesh_mushroom_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 3: {
+        metil_mesh_shuttle_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 4: {
+        metil_mesh_tube_initialize(
+          &object->mesh,
+          (struct clic3_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }, (struct clic3_vector2_unsigned_short_int) {
+            .x = 10,
+            .y = 10
+          }
+        );
+        break;
+      }
+      case 5: {
+        metil_mesh_ball_initialize(
+          &object->mesh,
+          2.0f * ((index_renderable * 3) % 10),
+          (struct clic3_vector2_unsigned_short_int) {
+            .x = 10 + (
+              index_renderable % 2
+            ),
+            .y = 10 + (
+              index_renderable % 3 == 0 ? 1 : 0
+            )
+          }
+        );
+        break;
+      }
+    }
 
     metil_object_buffers_initialize(
       object,
@@ -192,6 +197,68 @@ void example_fog_scene_initialize(
 
     data_object->color.w = 1.0f;
   }
+
+  metil_renderable_initialize_at_index(
+    scene->renderables,
+    0,
+    metil_renderable_type_object
+  );
+
+  object = (
+    scene->renderables[
+      0
+    ].renderable
+  );
+
+  metil_mesh_ball_initialize(
+    &object->mesh,
+    fog_distance_maximum,
+    (struct clic3_vector2_unsigned_short_int) {
+      .x = 100,
+      .y = 100
+    }
+  );
+
+  metil_object_buffers_initialize(
+    object,
+    metil->renderer_interface.metal_device
+  );
+
+  struct metil_renderer_data_object* data_object = (
+    object->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
+  );
+
+  data_object->color.x = (
+    1.0f
+  );
+
+  data_object->color.y = (
+    1.0f
+  );
+
+  data_object->color.z = (
+    1.0f
+  );
+
+  data_object->color.w = (
+    fog_thickness_maximum
+  );
+
+  object->index_pipeline_render = (
+    example_face_pipeline_index_fog
+  );
+
+  object->depth_disabled = 1;
+
+  object->rotation.x = M_PI / 2.0f;
+  object->rotation.z = M_PI / 2.0f;
+
+  scene->player.speed_movement = (
+    scene->player.speed_movement *
+    10.0f
+  );
 }
 
 void example_fog_scene_poll(
@@ -202,4 +269,14 @@ void example_fog_scene_poll(
     metil,
     scene
   );
+
+  struct metil_object* object = (
+    scene->renderables[
+      0
+    ].renderable
+  );
+
+  object->position.x = scene->player.position.x;
+  object->position.y = scene->player.position.y;
+  object->position.z = scene->player.position.z;
 }

--- a/sources/metil_mesh/metil_mesh_dollop.c
+++ b/sources/metil_mesh/metil_mesh_dollop.c
@@ -16,6 +16,10 @@ void metil_mesh_dollop_initialize(
     metil_mesh
   );
 
+  metil_mesh->size.x = size.x;
+  metil_mesh->size.y = size.y;
+  metil_mesh->size.z = size.z;
+
   struct clic3_vector3_float size_half = {
     .x = (
       size.x /
@@ -150,25 +154,20 @@ void metil_mesh_dollop_initialize(
     );
 
     if (
-      segments.y % 2 == 0
+      index_segment_y <= segment_y_half
     ) {
-      if (
-        index_segment_y <= segment_y_half
-      ) {
-        percentage_radius = (
-          (float) index_segment_y /
-          segment_y_half
-        );
-      } else {
-        percentage_radius = (
-          (
-            segments.y -
-            (float) index_segment_y
-          ) /
-          segment_y_half
-        );
-      }
+      percentage_radius = (
+        (float) index_segment_y /
+        segment_y_half
+      );
     } else {
+      percentage_radius = (
+        (
+          segments.y -
+          (float) index_segment_y
+        ) /
+        segment_y_half
+      );
     }
 
     percentage_radius = (

--- a/sources/metil_mesh/metil_mesh_gem.c
+++ b/sources/metil_mesh/metil_mesh_gem.c
@@ -16,6 +16,10 @@ void metil_mesh_gem_initialize(
     metil_mesh
   );
 
+  metil_mesh->size.x = size.x;
+  metil_mesh->size.y = size.y;
+  metil_mesh->size.z = size.z;
+
   struct clic3_vector3_float size_half = {
     .x = (
       size.x /
@@ -150,25 +154,20 @@ void metil_mesh_gem_initialize(
     );
 
     if (
-      segments.y % 2 == 0
+      index_segment_y <= segment_y_half
     ) {
-      if (
-        index_segment_y <= segment_y_half
-      ) {
-        percentage_radius = (
-          (float) index_segment_y /
-          segment_y_half
-        );
-      } else {
-        percentage_radius = (
-          (
-            segments.y -
-            (float) index_segment_y
-          ) /
-          segment_y_half
-        );
-      }
+      percentage_radius = (
+        (float) index_segment_y /
+        segment_y_half
+      );
     } else {
+      percentage_radius = (
+        (
+          segments.y -
+          (float) index_segment_y
+        ) /
+        segment_y_half
+      );
     }
 
     struct clic3_vector2_float radius = {

--- a/sources/metil_mesh/metil_mesh_mushroom.c
+++ b/sources/metil_mesh/metil_mesh_mushroom.c
@@ -16,6 +16,10 @@ void metil_mesh_mushroom_initialize(
     metil_mesh
   );
 
+  metil_mesh->size.x = size.x;
+  metil_mesh->size.y = size.y;
+  metil_mesh->size.z = size.z;
+
   struct clic3_vector3_float size_half = {
     .x = (
       size.x /

--- a/sources/metil_mesh/metil_mesh_shuttle.c
+++ b/sources/metil_mesh/metil_mesh_shuttle.c
@@ -16,6 +16,10 @@ void metil_mesh_shuttle_initialize(
     metil_mesh
   );
 
+  metil_mesh->size.x = size.x;
+  metil_mesh->size.y = size.y;
+  metil_mesh->size.z = size.z;
+
   struct clic3_vector3_float size_half = {
     .x = (
       size.x /

--- a/sources/metil_mesh/metil_mesh_tube.c
+++ b/sources/metil_mesh/metil_mesh_tube.c
@@ -16,6 +16,10 @@ void metil_mesh_tube_initialize(
     metil_mesh
   );
 
+  metil_mesh->size.x = size.x;
+  metil_mesh->size.y = size.y;
+  metil_mesh->size.z = size.z;
+
   struct clic3_vector3_float size_half = {
     .x = (
       size.x /


### PR DESCRIPTION
fog: an example of how to make fog work

may integrate this into it's own set of functionalities later on, may be possible to apply a fragment function globally after the rest in which case fog could be a `scene` property and apply to each renderable.

also fixes a bug with the additional meshes I added where sizes weren't being set and a few had dead conditional branches

#### fog with loose values

https://github.com/user-attachments/assets/a674d7b9-fb91-4a67-a138-e07892042d38

#### fog with tight values

https://github.com/user-attachments/assets/0639ef29-43d6-4eb0-b12c-c42b1afd91ae



