### PR TITLE
[enh] `metil`:add->{`metil_player_defaults`};

### DIFF
--- a/include/metil.h
+++ b/include/metil.h
@@ -6,6 +6,7 @@
 #include <metil_input/metil_input.h>
 #include <metil_library.h>
 #include <metil_paths/metil_paths.h>
+#include <metil_player/metil_player_defaults.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_rendering/metil_renderer_on_initialize.h>
 #include <metil_rendering/metil_rendering_properties.h>
@@ -29,6 +30,8 @@ struct metil {
   void* _Nonnull scene_controller;
   struct metil_system_information system_information;
   struct metil_termination termination;
+  
+  struct metil_player_defaults player_defaults;
   struct metil_text_characters text_characters_default;
   struct metil_text_defaults text_defaults;
 

--- a/include/metil_player/metil_player.h
+++ b/include/metil_player/metil_player.h
@@ -9,20 +9,20 @@
 struct metil_player;
 
 typedef void (*metil_player_poll_input_function)(
-  struct metil*,
-  struct metil_player*,
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull,
   unsigned long int,
   unsigned long int
 );
 
 typedef void (*metil_player_poll_function)(
-  struct metil*,
-  struct metil_player*
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull
 );
 
 typedef void (*metil_player_destroy_function)(
-  struct metil*,
-  struct metil_player*
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull
 );
 
 struct metil_player {
@@ -36,41 +36,40 @@ struct metil_player {
   float speed_movement;
   float speed_rotation;
 
-  metil_player_poll_input_function poll_input;
-  metil_player_poll_function poll;
-  metil_player_destroy_function destroy;
+  metil_player_poll_input_function _Nonnull poll_input;
+  metil_player_poll_function _Nonnull poll;
+  metil_player_destroy_function _Nonnull destroy;
 
-  struct metil_player_defaults defaults;
-
-  void* data;
+  void* _Nullable data;
 };
 
 void metil_player_initialize(
-  struct metil_player*
+  struct metil_player* _Nonnull,
+  struct metil_player_defaults* _Nonnull
 );
 
 void metil_player_poll_input(
-  struct metil*,
-  struct metil_player*,
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull,
   unsigned long int,
   unsigned long int
 );
 
 void metil_player_poll_input_null(
-  struct metil*,
-  struct metil_player*,
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull,
   unsigned long int,
   unsigned long int
 );
 
 void metil_player_poll(
-  struct metil*,
-  struct metil_player*
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull
 );
 
 void metil_player_destroy(
-  struct metil*,
-  struct metil_player*
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull
 );
 
 #endif

--- a/include/metil_player/metil_player_defaults.h
+++ b/include/metil_player/metil_player_defaults.h
@@ -17,8 +17,6 @@ struct metil_player_defaults {
   float deadzone_stick;
 
   struct clic3_vector3_float size;
-
-  unsigned char initialized;
 };
 
 void metil_player_defaults_initialize(

--- a/sources/metil.m
+++ b/sources/metil.m
@@ -3,6 +3,7 @@
 #include <metil_audio/metil_audio.h>
 #include <metil_configuration/metil_configuration.h>
 #include <metil_paths/metil_paths.h>
+#include <metil_player/metil_player_defaults.h>
 #include <metil_scenes/metil_scene_controller.h>
 #include <metil_text/metil_text.h>
 
@@ -13,6 +14,10 @@ void metil_structure_initialize(
 ) {
   metil->text_defaults.object_text_index_pipeline_render = (
     0
+  );
+
+  metil_player_defaults_initialize(
+    &metil->player_defaults
   );
 
   metil->scene_controller = malloc(

--- a/sources/metil_player/metil_player.m
+++ b/sources/metil_player/metil_player.m
@@ -10,16 +10,9 @@
 #include <math.h>
 
 void metil_player_initialize(
-  struct metil_player* metil_player
+  struct metil_player* metil_player,
+  struct metil_player_defaults* metil_player_defaults
 ) {
-  if (
-    metil_player->defaults.initialized != 1
-  ) {
-    metil_player_defaults_initialize(
-      &metil_player->defaults
-    );
-  }
-
   metil_player->position.x = 0.0f;
   metil_player->position.y = 0.0f;
   metil_player->position.z = 0.0f;
@@ -28,14 +21,14 @@ void metil_player_initialize(
   metil_player->rotation.y = 0.0f;
   metil_player->rotation.z = 0.0f;
 
-  metil_player->size.x = metil_player->defaults.size.x;
-  metil_player->size.y = metil_player->defaults.size.y;
-  metil_player->size.z = metil_player->defaults.size.z;
+  metil_player->size.x = metil_player_defaults->size.x;
+  metil_player->size.y = metil_player_defaults->size.y;
+  metil_player->size.z = metil_player_defaults->size.z;
 
-  metil_player->deadzone_stick = metil_player->defaults.deadzone_stick;
+  metil_player->deadzone_stick = metil_player_defaults->deadzone_stick;
 
-  metil_player->speed_movement = metil_player->defaults.speed_movement;
-  metil_player->speed_rotation = metil_player->defaults.speed_rotation;
+  metil_player->speed_movement = metil_player_defaults->speed_movement;
+  metil_player->speed_rotation = metil_player_defaults->speed_rotation;
 
   metil_player->velocity.x = 0.0f;
   metil_player->velocity.y = 0.0f;

--- a/sources/metil_player/metil_player_defaults.c
+++ b/sources/metil_player/metil_player_defaults.c
@@ -26,6 +26,4 @@ void metil_player_defaults_initialize(
   metil_player_defaults->size.z = (
     metil_player_defaults_size_default_z
   );
-
-  metil_player_defaults->initialized = 1;
 }

--- a/sources/metil_scenes/metil_scene.m
+++ b/sources/metil_scenes/metil_scene.m
@@ -25,7 +25,8 @@ void metil_scene_initialize_with_renderables(
   unsigned int length_renderables
 ) {
   metil_player_initialize(
-    &scene->player
+    &scene->player,
+    &metil->player_defaults
   );
 
   scene->length_renderables = length_renderables;


### PR DESCRIPTION
- move `metil_player_defaults` into `metil` instead of `metil_player`