### PR TITLE
[dev] `math.h` replacement with `math_c`

### DIFF
--- a/examples/3d_rendering/sources/example_3d_scene.m
+++ b/examples/3d_rendering/sources/example_3d_scene.m
@@ -10,7 +10,6 @@
 
 #include <clic3_vector.h>
 
-#include <math.h>
 #include <stdlib.h>
 
 void example_3d_scene_initialize(

--- a/examples/face/makefile
+++ b/examples/face/makefile
@@ -38,6 +38,7 @@ directory_interrupt_handler=../../../interrupt_handler
 directory_interrupt_handler_include=${directory_interrupt_handler}/include
 
 directory_math_c=../../../math_c
+directory_math_c_include=${directory_math_c}/include
 
 directory_metil_include=${directory_metil}/include
 directory_metil_plist=${directory_metil}/plist
@@ -115,7 +116,7 @@ files_objects_objc=${patsubst ${directory_sources}/%.m,${directory_objects_objc}
 frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
 
 cc=clang
-c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_interrupt_handler_include} -I${directory_metil_include}
+c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_interrupt_handler_include} -I${directory_math_c_include} -I${directory_metil_include}
 c_flags_platform=-target ${target_platform} -isysroot ${directory_sdk}
 
 c_flags_objc_debug=-O0 -g -v

--- a/examples/face/sources/example_face_scene.m
+++ b/examples/face/sources/example_face_scene.m
@@ -3,6 +3,9 @@
 #include <example_face_pipeline_index.h>
 #include <example_face_renderer_data_object.h>
 
+#include <math_c_power.h>
+#include <math_c_square_root.h>
+
 #include <metil.h>
 #include <metil_mesh/metil_mesh.h>
 #include <metil_input/metil_cursor.h>
@@ -11,8 +14,6 @@
 #include <metil_rendering/metil_renderable.h>
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_scenes/metil_scene.h>
-
-#include <math.h>
 
 void example_face_scene_initialize(
   struct metil* metil,
@@ -595,8 +596,8 @@ void example_face_scene_poll(
     );
 
     float distance = (
-      sqrt(
-        pow(
+      math_c_square_root(
+        math_c_power_float(
           (
             (
               vertex->x *
@@ -607,7 +608,7 @@ void example_face_scene_poll(
           ),
           2.0f
         ) +
-        pow(
+        math_c_power_float(
           (
             vertex->y *
             0.8f -

--- a/examples/fog/sources/example_fog_scene.m
+++ b/examples/fog/sources/example_fog_scene.m
@@ -18,7 +18,6 @@
 
 #include <clic3_vector.h>
 
-#include <math.h>
 #include <stdlib.h>
 
 void example_fog_scene_initialize(

--- a/examples/model/sources/example_model_scene.m
+++ b/examples/model/sources/example_model_scene.m
@@ -12,8 +12,6 @@
 #include <metil_rendering/metil_renderer_data_object.h>
 #include <metil_scenes/metil_scene.h>
 
-#include <math.h>
-
 void example_model_scene_initialize(
   struct metil* metil,
   struct metil_scene* scene

--- a/sources/metil_player/metil_player.m
+++ b/sources/metil_player/metil_player.m
@@ -7,8 +7,6 @@
 #include <metil_input/metil_keycodes.h>
 #include <metil_player/metil_player_defaults.h>
 
-#include <math.h>
-
 void metil_player_initialize(
   struct metil_player* metil_player,
   struct metil_player_defaults* metil_player_defaults

--- a/sources/metil_rendering/metil_camera/metil_camera.c
+++ b/sources/metil_rendering/metil_camera/metil_camera.c
@@ -2,8 +2,6 @@
 
 #include <metil_rendering/metil_camera/metil_camera_mode.h>
 
-#include <math.h>
-
 #include <simd/simd.h>
 
 void metil_camera_initialize(


### PR DESCRIPTION
removes unused instances of `math.h`

replaces `sqrt` and `pow` with `math_c` equivalents