### PR TITLE
[enh] `metil_player`:add->{`position_y_floor`};

### DIFF
--- a/include/metil_player/metil_player.h
+++ b/include/metil_player/metil_player.h
@@ -31,6 +31,8 @@ struct metil_player {
   struct clic3_vector3_float size;
   struct clic3_vector3_float velocity;
 
+  float position_y_floor;
+
   float deadzone_stick;
 
   float speed_movement;

--- a/sources/metil_player/metil_player.m
+++ b/sources/metil_player/metil_player.m
@@ -32,6 +32,8 @@ void metil_player_initialize(
   metil_player->velocity.y = 0.0f;
   metil_player->velocity.z = 0.0f;
 
+  metil_player->position_y_floor = 0.0f;
+
   metil_player->poll_input = metil_player_poll_input;
   metil_player->poll = metil_player_poll;
   metil_player->destroy = metil_player_destroy;
@@ -436,7 +438,7 @@ void metil_player_poll_input(
   );
 
   if (
-    metil_player->position.y > 0.0f
+    metil_player->position.y > metil_player->position_y_floor
   ) {
     metil_player->velocity.y = (
       metil_player->velocity.y - (
@@ -446,9 +448,12 @@ void metil_player_poll_input(
   }
 
   if (
-    metil_player->position.y < 0.0f
+    metil_player->position.y < metil_player->position_y_floor
   ) {
-    metil_player->position.y = 0.0f;
+    metil_player->position.y = (
+      metil_player->position_y_floor
+    );
+
     metil_player->velocity.y = 0.0f;
   }
 


### PR DESCRIPTION
- `metil_player`:add->{`position_y_floor`};
- - check `position_y_floor` during player `poll_input` for `velocity.y` value usage/calculations

allows y_movement on grounds not set to `0`

https://github.com/user-attachments/assets/ad1db3e2-4974-46a6-ad43-203f029bb372

