### PR TITLE
[bug] `metil_renderer`:make_clear_color_reflect_brightness

### DIFF
--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -318,9 +318,18 @@
 
   MTLRenderPassDescriptor* descriptor_render_pass = metal_kit_view.currentRenderPassDescriptor;
   descriptor_render_pass.colorAttachments[0].clearColor = MTLClearColorMake(
-    self->metil->rendering_properties.color_clear.x,
-    self->metil->rendering_properties.color_clear.y,
-    self->metil->rendering_properties.color_clear.z,
+    (
+      self->metil->rendering_properties.color_clear.x *
+      self->metil->rendering_properties.brightness
+    ),
+    (
+      self->metil->rendering_properties.color_clear.y *
+      self->metil->rendering_properties.brightness
+    ),
+    (
+      self->metil->rendering_properties.color_clear.z *
+      self->metil->rendering_properties.brightness
+    ),
     self->metil->rendering_properties.color_clear.w
   );
 


### PR DESCRIPTION
- `metil_renderer`:make_clear_color_reflect_brightness


if you want a solid color not affected by brightness then you can just set the clear color to be divided by brightness

it makes more sense to have the default be affected by brightness however, the cases in which you want a visible clear to change with brightness adjustments are going to be more often than when you want a solid color not affected by brightness