### PR TITLE
[enh]`metil` FPS RGBA color display

### DIFF
--- a/include/metil_configuration/metil_configuration_rendering_properties.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties.h
@@ -3,11 +3,14 @@
 
 #include <metil_configuration/metil_configuration_rendering_properties_defaults.h>
 
+#include <math_c_vector.h>
+
 struct metil_configuration_rendering_properties {
   float brightness;
   float brightness_text;
 
   unsigned char fps_display;
+  struct math_c_vector4_float color_fps_display;
 
   struct metil_configuration_rendering_properties_defaults defaults;
 };

--- a/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
@@ -1,16 +1,24 @@
 #ifndef __metil_configuration_metil_configuration_defaults_h
 #define __metil_configuration_metil_configuration_defaults_h
 
+#include <math_c_vector.h>
+
 #define metil_configuration_rendering_properties_default_brightness 1.0
 #define metil_configuration_rendering_properties_default_brightness_text 1.0
 
 #define metil_configuration_rendering_properties_default_fps_display 1
+
+#define metil_configuration_rendering_properties_default_color_fps_display_x 1.0f
+#define metil_configuration_rendering_properties_default_color_fps_display_y 1.0f
+#define metil_configuration_rendering_properties_default_color_fps_display_z 1.0f
+#define metil_configuration_rendering_properties_default_color_fps_display_w 1.0f
 
 struct metil_configuration_rendering_properties_defaults {
   float brightness;
   float brightness_text;
 
   unsigned char fps_display;
+  struct math_c_vector4_float color_fps_display;
 
   unsigned char initialized;
 };

--- a/include/metil_rendering/metil_rendering_properties.h
+++ b/include/metil_rendering/metil_rendering_properties.h
@@ -28,6 +28,7 @@ struct metil_rendering_properties {
   struct math_c_vector4_float color_clear;
 
   unsigned char fps_display;
+  struct math_c_vector4_float color_fps_display;
   float fps;
 
   unsigned char mode;

--- a/metal/metil_fps_display.metal
+++ b/metal/metil_fps_display.metal
@@ -7,7 +7,7 @@
 struct data_vertex {
   float4 position [[position]];
   float2 position_texture;
-  float3 color;
+  float4 color;
 };
 
 [[vertex]] struct data_vertex metil_fps_display_vertex(
@@ -47,10 +47,11 @@ struct data_vertex {
     vertices[id_vertex]
   );
 
-  data_vertex.color = float3(
-    1.0f,
-    1.0f,
-    1.0f
+  data_vertex.color = float4(
+    data_object->color.x,
+    data_object->color.y,
+    data_object->color.z,
+    data_object->color.w
   );
 
   return data_vertex;
@@ -76,6 +77,6 @@ struct data_vertex {
     color_texture[0] * data_vertex.color.r,
     color_texture[1] * data_vertex.color.g,
     color_texture[2] * data_vertex.color.b,
-    color_texture[3]
+    color_texture[3] * data_vertex.color.a
   );
 }

--- a/sources/metil_configuration/metil_configuration.m
+++ b/sources/metil_configuration/metil_configuration.m
@@ -162,11 +162,15 @@ unsigned char metil_configuration_load(
 
         int index_parameter = clic3_char_arrays_within(
           buffer_parameter,
-          4,
+          8,
           "audio:volume",
           "rendering_properties:brightness",
           "rendering_properties:brightness_text",
-          "rendering_properties:fps_display"
+          "rendering_properties:fps_display",
+          "rendering_properties:color_fps_display_r",
+          "rendering_properties:color_fps_display_g",
+          "rendering_properties:color_fps_display_b",
+          "rendering_properties:color_fps_display_a"
         );
 
         if (
@@ -257,6 +261,86 @@ unsigned char metil_configuration_load(
               fps_display != -1
             ) {
               metil_configuration->rendering_properties.fps_display = fps_display;
+            } else {
+              status_configuration_load = 1;
+            }
+
+            break;
+          }
+          case 4: {
+            float color_fps_display_r = metil_configuration_value_float_parse(
+              metil_configuration,
+              buffer_parameter,
+              buffer_value
+            );
+
+            if (
+              color_fps_display_r >= 0.0f &&
+              color_fps_display_r <= 1.0f
+            ) {
+              metil_configuration->rendering_properties.color_fps_display.x = (
+                color_fps_display_r
+              );
+            } else {
+              status_configuration_load = 1;
+            }
+            
+            break;
+          }
+          case 5: {
+            float color_fps_display_g = metil_configuration_value_float_parse(
+              metil_configuration,
+              buffer_parameter,
+              buffer_value
+            );
+
+            if (
+              color_fps_display_g >= 0.0f &&
+              color_fps_display_g <= 1.0f
+            ) {
+              metil_configuration->rendering_properties.color_fps_display.y = (
+                color_fps_display_g
+              );
+            } else {
+              status_configuration_load = 1;
+            }
+
+            break;
+          }
+          case 6: {
+            float color_fps_display_b = metil_configuration_value_float_parse(
+              metil_configuration,
+              buffer_parameter,
+              buffer_value
+            );
+
+            if (
+              color_fps_display_b >= 0.0f &&
+              color_fps_display_b <= 1.0f
+            ) {
+              metil_configuration->rendering_properties.color_fps_display.z = (
+                color_fps_display_b
+              );
+            } else {
+              status_configuration_load = 1;
+            }
+
+            break;
+          }
+          case 7: {
+            float color_fps_display_a = metil_configuration_value_float_parse(
+              metil_configuration,
+              buffer_parameter,
+              buffer_value
+            );
+
+            if (
+              color_fps_display_a >= 0.0f &&
+              color_fps_display_a <= 1.0f
+            ) {
+              metil_configuration->rendering_properties.color_fps_display.w = (
+                color_fps_display_a
+              );
             } else {
               status_configuration_load = 1;
             }

--- a/sources/metil_configuration/metil_configuration_rendering_properties.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties.c
@@ -22,4 +22,20 @@ void metil_configuration_rendering_properties_initialize(
   metil_configuration_rendering_properties->fps_display = (
     metil_configuration_rendering_properties->defaults.fps_display
   );
+
+  metil_configuration_rendering_properties->color_fps_display.x = (
+    metil_configuration_rendering_properties->defaults.color_fps_display.x
+  );
+
+  metil_configuration_rendering_properties->color_fps_display.y = (
+    metil_configuration_rendering_properties->defaults.color_fps_display.y
+  );
+
+  metil_configuration_rendering_properties->color_fps_display.z = (
+    metil_configuration_rendering_properties->defaults.color_fps_display.z
+  );
+
+  metil_configuration_rendering_properties->color_fps_display.w = (
+    metil_configuration_rendering_properties->defaults.color_fps_display.w
+  );
 }

--- a/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
@@ -15,6 +15,22 @@ void metil_configuration_rendering_properties_defaults_initialize(
     metil_configuration_rendering_properties_default_fps_display
   );
 
+  metil_configuration_rendering_properties_defaults->color_fps_display.x = (
+    metil_configuration_rendering_properties_default_color_fps_display_x
+  );
+
+  metil_configuration_rendering_properties_defaults->color_fps_display.y = (
+    metil_configuration_rendering_properties_default_color_fps_display_y
+  );
+
+  metil_configuration_rendering_properties_defaults->color_fps_display.z = (
+    metil_configuration_rendering_properties_default_color_fps_display_z
+  );
+
+  metil_configuration_rendering_properties_defaults->color_fps_display.w = (
+    metil_configuration_rendering_properties_default_color_fps_display_w
+  );
+
   metil_configuration_rendering_properties_defaults->initialized = (
     1
   );

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -894,7 +894,9 @@
     self->metil->rendering_properties.fps
   );
 
-  float position_x = 0.0f;
+  float position_x = (
+    0.0f
+  );
 
   for (
     signed char index_object_fps_display = metil_renderer_length_objects_fps_display - 1;
@@ -910,18 +912,31 @@
     self->objects_fps_display[
       index_object_fps_display
     ].mesh = self->metil->text_characters_default.meshes[
-      char_array_fps[index_object_fps_display]
+      char_array_fps[
+        index_object_fps_display
+      ]
     ];
 
-    position_x = position_x + self->objects_fps_display[
-      index_object_fps_display
-    ].mesh.size.x / self->metil->rendering_properties.camera.ratio_aspect_view;
+    position_x = (
+      position_x +
+      self->objects_fps_display[
+        index_object_fps_display
+      ].mesh.size.x /
+      self->metil->rendering_properties.camera.ratio_aspect_view
+    );
 
     self->objects_fps_display[
       index_object_fps_display
-    ].position.x = 1.0f - position_x;
+    ].position.x = (
+      1.0f -
+      position_x
+    );
 
-    if (char_array_fps[index_object_fps_display] == '.') {
+    if (
+      char_array_fps[
+        index_object_fps_display
+      ] == '.'
+    ) {
       self->objects_fps_display[
         index_object_fps_display
       ].position.x = self->objects_fps_display[
@@ -956,18 +971,6 @@
 
     self->objects_fps_display[
       index_object_fps_display
-    ].buffers_vertex[
-      metil_object_buffer_default_index_vertices
-    ].offset = 0;
-
-    self->objects_fps_display[
-      index_object_fps_display
-    ].buffers_vertex[
-      metil_object_buffer_default_index_vertices
-    ].index = metil_object_buffer_default_index_data;
-
-    self->objects_fps_display[
-      index_object_fps_display
     ].textures[0] = (
       self->metil->text_characters_default.textures[
         char_array_fps[index_object_fps_display]
@@ -988,7 +991,9 @@
     );
   }
 
-  free(char_array_fps);
+  free(
+    char_array_fps
+  );
 }
 
 - (void) render_renderable:
@@ -1108,6 +1113,30 @@
     index_object_fps_display < metil_renderer_length_objects_fps_display;
     ++index_object_fps_display
   ) {
+    struct metil_renderer_data_object* metil_renderer_data_object = (
+      self->objects_fps_display[
+        index_object_fps_display
+      ].buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
+    );
+
+    metil_renderer_data_object->color.x = (
+      self->metil->rendering_properties.color_fps_display.x
+    );
+
+    metil_renderer_data_object->color.y = (
+      self->metil->rendering_properties.color_fps_display.y
+    );
+
+    metil_renderer_data_object->color.z = (
+      self->metil->rendering_properties.color_fps_display.z
+    );
+
+    metil_renderer_data_object->color.w = (
+      self->metil->rendering_properties.color_fps_display.w
+    );
+
     [self
       render_object: &self->objects_fps_display[
         index_object_fps_display

--- a/sources/metil_rendering/metil_rendering_properties.c
+++ b/sources/metil_rendering/metil_rendering_properties.c
@@ -43,6 +43,23 @@ void metil_rendering_properties_initialize(
   metil_rendering_properties->fps_display = (
     metil_configuration_rendering_properties->fps_display
   );
+
+  metil_rendering_properties->color_fps_display.x = (
+    metil_configuration_rendering_properties->color_fps_display.x
+  );
+
+  metil_rendering_properties->color_fps_display.y = (
+    metil_configuration_rendering_properties->color_fps_display.y
+  );
+
+  metil_rendering_properties->color_fps_display.z = (
+    metil_configuration_rendering_properties->color_fps_display.z
+  );
+
+  metil_rendering_properties->color_fps_display.w = (
+    metil_configuration_rendering_properties->color_fps_display.w
+  );
+
   metil_rendering_properties->fps = 0.0f;
 
   for (


### PR DESCRIPTION
- adds colors to fps display
- adds configuration values
- - `rendering_properties:color_fps_display_r`
- - `rendering_properties:color_fps_display_g`
- - `rendering_properties:color_fps_display_b`
- - `rendering_properties:color_fps_display_a`

allows for transparent displays

<img width="91" height="67" alt="Screenshot 2026-01-09 at 10 37 36" src="https://github.com/user-attachments/assets/c766bac6-78a6-46d8-9a68-98e0454b395a" />
<img width="103" height="75" alt="Screenshot 2026-01-09 at 10 38 30" src="https://github.com/user-attachments/assets/b8248f17-3262-4360-bbed-fb08332f6f05" />
<img width="88" height="98" alt="Screenshot 2026-01-09 at 10 39 51" src="https://github.com/user-attachments/assets/89fd3761-8564-43c7-88da-d588c4d4360d" />
<img width="89" height="86" alt="Screenshot 2026-01-09 at 10 40 05" src="https://github.com/user-attachments/assets/aae6ef3a-aaa2-4c85-b590-161a85888f2e" />
<img width="194" height="145" alt="Screenshot 2026-01-09 at 10 40 29" src="https://github.com/user-attachments/assets/5db173a2-6bb1-43ea-8957-68a14e612e5f" />
