### PR TITLE
[enh] Model vertex calcluation to metal

### DIFF
--- a/examples/model/makefile
+++ b/examples/model/makefile
@@ -94,7 +94,9 @@ directory_sdk=${shell xcrun --sdk macosx${target_device_version} --show-sdk-path
 file_metil_storyboard=${directory_metil_library}/metil.storyboardc
 
 file_metalar_metil_fps_display=${directory_metil_library}/metil_fps_display.metalar
+file_metalar_metil_=${directory_metil_library}/metil_wireframe.metalar
 file_metalar_metil_wireframe=${directory_metil_library}/metil_wireframe.metalar
+file_metalar_metil_metal_model_object=${directory_metil_library}/metil_metal_model_object.metalar
 
 file_info_plist=${directory_metil_plist}/Info.plist
 file_output=${directory_app_contents_macos}/${name}
@@ -184,7 +186,7 @@ endif
 
 ${file_output_metal}: ${files_air}
 	mkdir -p "${dir ${file_output_metal}}"
-	${metallib} ${metal_flags_output} ${files_air} ${file_metalar_metil_wireframe} ${file_metalar_metil_fps_display} -o ${file_output_metal}
+	${metallib} ${metal_flags_output} ${files_air} ${file_metalar_metil_wireframe} ${file_metalar_metil_fps_display} ${file_metalar_metil_metal_model_object} -o ${file_output_metal}
 
 ${directory_air}/%.air: ${directory_metal}/%.metal
 	mkdir -p "${dir $@}"

--- a/examples/model/metal/model.metal
+++ b/examples/model/metal/model.metal
@@ -1,4 +1,5 @@
 #include <metil_joint/metil_joint_id_offset.h>
+#include <metil_metal/metil_metal_model_object.h>
 #include <metil_rendering/metil_renderer_data_frame.h>
 #include <metil_rendering/metil_renderer_vertex_index_parameter.h>
 #include <metil_rendering/metil_renderer_data_model_object.h>
@@ -38,90 +39,16 @@ struct data_vertex {
 ) {
   struct data_vertex data_vertex;
 
-  unsigned int id_joint = (
-    vertex_joint_map[
-      id_vertex
-    ] *
-    metil_joint_id_offset_length
-  );
-
-  unsigned int id_joint_position = (
-    id_joint +
-    metil_joint_id_offset_position
-  );
-
-  unsigned int id_joint_rotation = (
-    id_joint +
-    metil_joint_id_offset_rotation
-  );
-
-  unsigned int id_joint_translation = (
-    id_joint +
-    metil_joint_id_offset_translation
-  );
-
-  matrix_float4x4 matrix_projection_object_with_rotation = (
-    (matrix_float4x4) {{
-      { metal::cos(joints[id_joint_rotation].y), 0.0f, -metal::sin(joints[id_joint_rotation].y), 0.0f },
-      { 0.0f, 1.0f, 0.0f, 0.0f },
-      { metal::sin(joints[id_joint_rotation].y), 0.0f, metal::cos(joints[id_joint_rotation].y), 0.0f },
-      { 0.0f, 0.0f, 0.0f, 1.0f }
-    }} *
-    (matrix_float4x4) {{
-      { 1.0f, 0.0f, 0.0f, 0.0f },
-      { 0.0f, metal::cos(joints[id_joint_rotation].x), -metal::sin(joints[id_joint_rotation].x), 0.0f },
-      { 0.0f, metal::sin(joints[id_joint_rotation].x), metal::cos(joints[id_joint_rotation].x), 0.0f },
-      { 0.0f, 0.0f, 0.0f, 1.0f }
-    }} *
-    (matrix_float4x4) {{
-      { metal::cos(joints[id_joint_rotation].z), -metal::sin(joints[id_joint_rotation].z), 0.0f, 0.0f },
-      { metal::sin(joints[id_joint_rotation].z), metal::cos(joints[id_joint_rotation].z), 0.0f, 0.0f },
-      { 0.0f, 0.0f, 1.0f, 0.0f },
-      { 0.0f, 0.0f, 0.0f, 1.0f }
-    }}
-  );
-
-  float4 position_object = {
-    data_object->position.x,
-    data_object->position.y,
-    data_object->position.z,
-    0.0f
-  };
-
-  float4 position_vertex_object_relation = (
-    vertices[id_vertex] +
-    position_object
-  );
-
-  float4 position_joint = {
-    joints[id_joint_position].x,
-    joints[id_joint_position].y,
-    joints[id_joint_position].z,
-    0.0f
-  };
-
-  float4 position_joint_translation = {
-    joints[id_joint_translation].x,
-    joints[id_joint_translation].y,
-    joints[id_joint_translation].z,
-    0.0f
-  };
-
-  float4 position_vertex_object_relation_offset_joint_origin = (
-    position_vertex_object_relation - 
-    position_joint
-  );
-
-  float4 position_vertex_object_relation_offset_joint_origin_rotated = (
-    position_vertex_object_relation_offset_joint_origin *
-    matrix_projection_object_with_rotation
-  );
-  
   float4 position_vertex = (
-    position_vertex_object_relation_offset_joint_origin_rotated +
-    position_joint +
-    position_joint_translation -
-    position_object
+    metil_model_object_position_calcluate(
+      id_vertex,
+      &vertices[
+        id_vertex
+      ],
+      &data_object->position,
+      vertex_joint_map,
+      joints
+    )
   );
 
   data_vertex.position = (

--- a/include/metil_metal/metil_metal_model_object.h
+++ b/include/metil_metal/metil_metal_model_object.h
@@ -1,0 +1,16 @@
+#ifndef __metil_metal_metil_metal_model_object_h
+#define __metil_metal_metil_metal_model_object_h
+
+#include <math_c_vector.h>
+
+#include <simd/simd.h>
+
+float4 metil_model_object_position_calcluate(
+  unsigned int,
+  const device float4*,
+  constant struct math_c_vector3_float*,
+  constant unsigned int*,
+  constant struct math_c_vector3_float*
+);
+
+#endif

--- a/makefile
+++ b/makefile
@@ -138,8 +138,6 @@ target_platform_metal=air64-apple-ios${target_metal_version}
 directory_sdk=${shell xcrun --sdk iphoneos${target_device_version} --show-sdk-path}
 endif
 
-file_air_fps_display=${directory_air}/metil_fps_display.air
-file_air_wireframe=${directory_air}/metil_wireframe.air
 file_info_plist=${directory_plist}/Info.plist
 
 file_library_object=${directory_library}/${name}.o
@@ -155,11 +153,7 @@ file_library_dynamic_major=${directory_library}/${name_library_dynamic_major}
 file_library_static=${directory_library}/${name}.a
 
 file_metalar_metil_all=${directory_metalar}/metil_all.metalar
-file_metalar_metil_fps_display=${directory_metalar}/metil_fps_display.metalar
-file_metalar_metil_wireframe=${directory_metalar}/metil_wireframe.metalar
 file_output_metalar_metil_all=${directory_library}/metil_all.metalar
-file_output_metalar_metil_fps_display=${directory_library}/metil_fps_display.metalar
-file_output_metalar_metil_wireframe=${directory_library}/metil_wireframe.metalar
 
 ifeq (${target_device},iphone)
 file_output_info_plist=${directory_library}/Info_ios.plist
@@ -176,6 +170,8 @@ files_objects_objc=${patsubst ${directory_sources}/%.m,${directory_objects_objc}
 
 files_metal=${wildcard ${directory_metal}/*.metal}
 files_air=${patsubst ${directory_metal}/%.metal,${directory_air}/%.air,${files_metal}}
+files_metalar=${patsubst ${directory_air}/%.air,${directory_metalar}/%.metalar,${files_air}}
+files_output_metalar=${patsubst ${directory_metalar}/%.metalar,${directory_library}/%.metalar,${files_metalar}}
 
 files_storyboards=${wildcard ${directory_storyboards}/*.storyboard}
 
@@ -247,7 +243,7 @@ endif
 
 metal_flags_output=
 
-${name}: ${file_library_dylib} ${file_library_dynamic} ${file_library_object} ${file_library_static} ${file_output_metal} ${file_output_metalar_metil_all} ${file_output_metalar_metil_fps_display} ${file_output_metalar_metil_wireframe} ${files_storyboards_compiled} ${file_output_info_plist}
+${name}: ${file_library_dylib} ${file_library_dynamic} ${file_library_object} ${file_library_static} ${file_output_metal} ${file_output_metalar_metil_all} ${files_metalar} ${files_output_metalar} ${files_storyboards_compiled} ${file_output_info_plist}
 
 all: ${name} examples
 
@@ -301,15 +297,10 @@ ${file_metalar_metil_all}: ${files_air}
 	if [[ -f ${file_metalar_metil_all} ]]; then rm ${file_metalar_metil_all}; fi
 	${metal_ar} -rc ${file_metalar_metil_all} ${files_air}
 
-${file_metalar_metil_fps_display}: ${file_air_fps_display}
+${directory_metalar}/%.metalar: ${directory_air}/%.air
 	mkdir -p ${directory_metalar}
-	if [[ -f ${file_metalar_metil_fps_display} ]]; then rm ${file_metalar_metil_fps_display}; fi
-	${metal_ar} -rc ${file_metalar_metil_fps_display} ${file_air_fps_display}
-
-${file_metalar_metil_wireframe}: ${file_air_wireframe}
-	mkdir -p ${directory_metalar}
-	if [[ -f ${file_metalar_metil_wireframe} ]]; then rm ${file_metalar_metil_wireframe}; fi
-	${metal_ar} -rc ${file_metalar_metil_wireframe} ${file_air_wireframe}
+	if [[ -f "$@" ]]; then rm "$@"; fi
+	${metal_ar} -rc "$@" "$<"
 
 ${directory_air}/%.air: ${directory_metal}/%.metal
 	mkdir -p ${directory_air}

--- a/metal/metil_metal_model_object.metal
+++ b/metal/metil_metal_model_object.metal
@@ -1,0 +1,105 @@
+#include <metil_metal/metil_metal_model_object.h>
+
+#include <metil_joint/metil_joint_id_offset.h>
+
+#include <math_c_vector.h>
+
+#include <simd/simd.h>
+
+float4 metil_model_object_position_calcluate(
+  unsigned int id_vertex,
+  const device float4* position_vertex,
+  constant struct math_c_vector3_float* position,
+  constant unsigned int* vertex_joint_map,
+  constant struct math_c_vector3_float* joints
+) {
+  unsigned int id_joint = (
+    vertex_joint_map[
+      id_vertex
+    ] *
+    metil_joint_id_offset_length
+  );
+
+  unsigned int id_joint_position = (
+    id_joint +
+    metil_joint_id_offset_position
+  );
+
+  unsigned int id_joint_rotation = (
+    id_joint +
+    metil_joint_id_offset_rotation
+  );
+
+  unsigned int id_joint_translation = (
+    id_joint +
+    metil_joint_id_offset_translation
+  );
+
+  matrix_float4x4 matrix_projection_object_with_rotation = (
+    (matrix_float4x4) {{
+      { metal::cos(joints[id_joint_rotation].y), 0.0f, -metal::sin(joints[id_joint_rotation].y), 0.0f },
+      { 0.0f, 1.0f, 0.0f, 0.0f },
+      { metal::sin(joints[id_joint_rotation].y), 0.0f, metal::cos(joints[id_joint_rotation].y), 0.0f },
+      { 0.0f, 0.0f, 0.0f, 1.0f }
+    }} *
+    (matrix_float4x4) {{
+      { 1.0f, 0.0f, 0.0f, 0.0f },
+      { 0.0f, metal::cos(joints[id_joint_rotation].x), -metal::sin(joints[id_joint_rotation].x), 0.0f },
+      { 0.0f, metal::sin(joints[id_joint_rotation].x), metal::cos(joints[id_joint_rotation].x), 0.0f },
+      { 0.0f, 0.0f, 0.0f, 1.0f }
+    }} *
+    (matrix_float4x4) {{
+      { metal::cos(joints[id_joint_rotation].z), -metal::sin(joints[id_joint_rotation].z), 0.0f, 0.0f },
+      { metal::sin(joints[id_joint_rotation].z), metal::cos(joints[id_joint_rotation].z), 0.0f, 0.0f },
+      { 0.0f, 0.0f, 1.0f, 0.0f },
+      { 0.0f, 0.0f, 0.0f, 1.0f }
+    }}
+  );
+
+  float4 position_object = {
+    position->x,
+    position->y,
+    position->z,
+    0.0f
+  };
+
+  float4 position_vertex_object_relation = (
+    *position_vertex +
+    position_object
+  );
+
+  float4 position_joint = {
+    joints[id_joint_position].x,
+    joints[id_joint_position].y,
+    joints[id_joint_position].z,
+    0.0f
+  };
+
+  float4 position_joint_translation = {
+    joints[id_joint_translation].x,
+    joints[id_joint_translation].y,
+    joints[id_joint_translation].z,
+    0.0f
+  };
+
+  float4 position_vertex_object_relation_offset_joint_origin = (
+    position_vertex_object_relation - 
+    position_joint
+  );
+
+  float4 position_vertex_object_relation_offset_joint_origin_rotated = (
+    position_vertex_object_relation_offset_joint_origin *
+    matrix_projection_object_with_rotation
+  );
+  
+  float4 position_vertex_transformed = (
+    position_vertex_object_relation_offset_joint_origin_rotated +
+    position_joint +
+    position_joint_translation -
+    position_object
+  );
+
+  return (
+    position_vertex_transformed
+  );
+}


### PR DESCRIPTION
adds model object vertex calculation to it's own metal file

you can include the metalar or use the all metalar/metallib

converts all air files to metalar files (when i have more metal files that get compiled i will likely change this to group specific metal and air files by their usage)

updates the model example to use the new metalar