### PR TITLE
[bug|enh] add_scrolling_type_to_metil_menu_item

### DIFF
--- a/include/metil_menus/metil_menu_item.h
+++ b/include/metil_menus/metil_menu_item.h
@@ -6,19 +6,28 @@ struct metil_menu_item;
 typedef void (*metil_menu_item_on_action)(struct metil_menu_item*);
 
 enum metil_menu_item_type {
-  metil_menu_item_type_display,
-  metil_menu_item_type_submenu,
-  metil_menu_item_type_selection
+  metil_menu_item_type_display = 0,
+  metil_menu_item_type_submenu = 1,
+  metil_menu_item_type_selection = 2,
+  metil_menu_item_type_scroll = 3
 };
 
 enum metil_menu_item_action {
-  metil_menu_item_action_none,
-  metil_menu_item_action_select
+  metil_menu_item_action_none = 0,
+  metil_menu_item_action_select = 1
+};
+
+struct metil_menu_item_data_scroll {
+  unsigned int length;
+  unsigned int index;
+  unsigned char wrap;
 };
 
 struct metil_menu_item {
   enum metil_menu_item_type type;
   enum metil_menu_item_action action;
+
+  void* data_menu_item;
   void* data;
 };
 
@@ -27,6 +36,18 @@ void metil_menu_item_initialize(
   enum metil_menu_item_type,
   enum metil_menu_item_action,
   void*
+);
+
+unsigned char metil_menu_item_scroll_next(
+  struct metil_menu_item*
+);
+
+unsigned char metil_menu_item_scroll_previous(
+  struct metil_menu_item*
+);
+
+void metil_menu_item_destroy(
+  struct metil_menu_item*
 );
 
 #endif

--- a/sources/metil_menus/metil_menu.c
+++ b/sources/metil_menus/metil_menu.c
@@ -61,7 +61,11 @@ void metil_menu_select(
   struct metil_menu* menu
 ) {
   if (
-    menu->length_items == 0
+    menu->length_items == 0 ||
+    menu->index_current > menu->length_items ||
+    menu->items[
+      menu->index_current
+    ].action != metil_menu_item_action_select
   ) {
     return;
   }
@@ -118,9 +122,21 @@ unsigned char metil_menu_previous(
 }
 
 void metil_menu_destroy(
-  struct metil_menu* menu
+  struct metil_menu* metil_menu
 ) {
+  for (
+    unsigned char index_metil_menu_item = 0;
+    index_metil_menu_item < metil_menu->length_items;
+    ++index_metil_menu_item
+  ) {
+    metil_menu_item_destroy(
+      &metil_menu->items[
+        index_metil_menu_item
+      ]
+    );
+  }
+
   clic3_memory_free(
-    menu->items
+    metil_menu->items
   );
 }

--- a/sources/metil_menus/metil_menu_input.m
+++ b/sources/metil_menus/metil_menu_input.m
@@ -6,18 +6,18 @@
 #include <metil_utilities/metil_stopwatch.h>
 
 void metil_menu_poll_input(
-  struct metil_menu* menu,
+  struct metil_menu* metil_menu,
   struct metil_input* metil_input
 ) {
   if (
-    menu->index_selected != -1
+    metil_menu->index_selected != -1
   ) {
     return;
   }
 
   unsigned long int delta = (
     metil_stopwatch_elapsed(
-      &menu->stopwatch_input
+      &metil_menu->stopwatch_input
     )
   );
 
@@ -27,14 +27,48 @@ void metil_menu_poll_input(
     return;
   }
 
+  enum metil_menu_item_action metil_menu_item_action = (
+    metil_menu_item_action_none
+  );
+
+  enum metil_menu_item_type metil_menu_item_type = (
+    metil_menu_item_type_display
+  );
+  
+  struct metil_menu_item* metil_menu_item = (
+    (void*) 0
+  );
+
   if (
-    metil_input->keydown_map[
-      metil_keycode_space
-    ] == 1 ||
-    metil_input->controller_state.cross > 0.0f
+    metil_menu->index_current < metil_menu->length_items
+  ) {
+    metil_menu_item = (
+      &metil_menu->items[
+        metil_menu->index_current
+      ]
+    );
+
+    metil_menu_item_action = (
+      metil_menu_item->action
+    );
+
+    metil_menu_item_type = (
+      metil_menu_item->type
+    );
+  }
+
+  if (
+    (
+      metil_menu_item_action == metil_menu_item_action_select
+    ) && (
+      metil_input->keydown_map[
+        metil_keycode_space
+      ] == 1 ||
+      metil_input->controller_state.cross > 0.0f
+    )
   ) {
     metil_menu_select(
-      menu
+      metil_menu
     );
 
     return;
@@ -56,7 +90,7 @@ void metil_menu_poll_input(
     );
 
     metil_menu_previous(
-      menu
+      metil_menu
     );
   } else if (
     metil_input->keydown_map[
@@ -70,15 +104,47 @@ void metil_menu_poll_input(
     );
 
     metil_menu_next(
-      menu
+      metil_menu
     );
+  } else if (
+    metil_menu_item_type == metil_menu_item_type_scroll
+  ) {
+    if (
+      metil_input->keydown_map[
+        metil_keycode_left_arrow
+      ] == 1 ||
+      metil_input->controller_state.directional_left > 0.0f ||
+      metil_input->controller_state.left_stick.x < -0.1f
+    ) {
+      had_input = (
+        1
+      );
+
+      metil_menu_item_scroll_previous(
+        metil_menu_item
+      );
+    } else if (
+      metil_input->keydown_map[
+        metil_keycode_right_arrow
+      ] == 1 ||
+      metil_input->controller_state.directional_right > 0.0f ||
+      metil_input->controller_state.left_stick.x > 0.1f
+    ) {
+      had_input = (
+        1
+      );
+
+      metil_menu_item_scroll_next(
+        metil_menu_item
+      );
+    }
   }
 
   if (
     had_input == 1
   ) {
     metil_stopwatch_start(
-      &menu->stopwatch_input
+      &metil_menu->stopwatch_input
     );
   }
 }

--- a/sources/metil_menus/metil_menu_item.c
+++ b/sources/metil_menus/metil_menu_item.c
@@ -1,12 +1,122 @@
 #include <metil_menus/metil_menu_item.h>
 
+#include <clic3_memory.h>
+
+#include <stdlib.h>
+
 void metil_menu_item_initialize(
-  struct metil_menu_item* menu_item,
-  enum metil_menu_item_type type,
-  enum metil_menu_item_action action,
+  struct metil_menu_item* metil_menu_item,
+  enum metil_menu_item_type metil_menu_item_type,
+  enum metil_menu_item_action metil_menu_item_action,
   void* data
 ) {
-  menu_item->type = type;
-  menu_item->action = action;
-  menu_item->data = data;
+  metil_menu_item->action = (
+    metil_menu_item_action
+  );
+
+  metil_menu_item->data = (
+    data
+  );
+  
+  switch (
+    metil_menu_item_type
+  ) {
+    case metil_menu_item_type_scroll: {
+      metil_menu_item->data_menu_item = (
+        malloc(
+          sizeof(
+            struct metil_menu_item_data_scroll
+          )
+        )
+      );
+
+      struct metil_menu_item_data_scroll* metil_menu_item_data_scroll = (
+        metil_menu_item->data_menu_item
+      );
+
+      metil_menu_item_data_scroll->index = 0;
+      metil_menu_item_data_scroll->length = 1;
+      metil_menu_item_data_scroll->wrap = 1;
+
+      break;
+    }
+    default: {
+      metil_menu_item->data_menu_item = (
+        (void*) 0
+      );
+
+      break;
+    }
+  }
+  
+  metil_menu_item->type = (
+    metil_menu_item_type
+  );
+}
+#include <stdio.h>
+
+unsigned char metil_menu_item_scroll_next(
+  struct metil_menu_item* metil_menu_item_scroll
+) {
+  struct metil_menu_item_data_scroll* metil_menu_item_data_scroll = (
+    metil_menu_item_scroll->data_menu_item
+  );
+
+  if (
+    metil_menu_item_data_scroll->index == metil_menu_item_data_scroll->length - 1
+  ) {
+    if (
+      metil_menu_item_data_scroll->wrap == 0
+    ) {
+      return 1;
+    }
+
+    metil_menu_item_data_scroll->index = 0;
+  } else {
+    metil_menu_item_data_scroll->index = (
+      metil_menu_item_data_scroll->index + 1
+    );
+  }
+
+  return 0;
+}
+
+unsigned char metil_menu_item_scroll_previous(
+  struct metil_menu_item* metil_menu_item_scroll
+) {
+  struct metil_menu_item_data_scroll* metil_menu_item_data_scroll = (
+    metil_menu_item_scroll->data_menu_item
+  );
+
+  if (
+    metil_menu_item_data_scroll->index == 0
+  ) {
+    if (
+      metil_menu_item_data_scroll->wrap == 0
+    ) {
+      return 1;
+    }
+
+    metil_menu_item_data_scroll->index = (
+      metil_menu_item_data_scroll->length - 1
+    );
+  } else {
+    metil_menu_item_data_scroll->index = (
+      metil_menu_item_data_scroll->index - 1
+    );
+  }
+
+  return 0;
+}
+
+void metil_menu_item_destroy(
+  struct metil_menu_item* metil_menu_item
+) {
+  clic3_memory_free(
+    metil_menu_item->data
+  );
+
+  clic3_memory_free(
+    metil_menu_item->data_menu_item
+  );
 }

--- a/sources/metil_menus/metil_menu_item.c
+++ b/sources/metil_menus/metil_menu_item.c
@@ -53,7 +53,6 @@ void metil_menu_item_initialize(
     metil_menu_item_type
   );
 }
-#include <stdio.h>
 
 unsigned char metil_menu_item_scroll_next(
   struct metil_menu_item* metil_menu_item_scroll

--- a/sources/metil_utilities/metil_stopwatch.c
+++ b/sources/metil_utilities/metil_stopwatch.c
@@ -4,19 +4,26 @@
 #include <sys/time.h>
 
 void metil_stopwatch_start(
-  struct metil_stopwatch* stopwatch
+  struct metil_stopwatch* metil_stopwatch
 ) {
   gettimeofday(
-    &stopwatch->timeval,
-    (void*)0
+    &metil_stopwatch->timeval,
+    (void*) 0
   );
 }
 
 unsigned long int metil_stopwatch_elapsed(
-  struct metil_stopwatch* stopwatch
+  struct metil_stopwatch* metil_stopwatch
 ) {
-  return metil_time_milliseconds_get() - (
-    metil_time_seconds_to_milliseconds(stopwatch->timeval.tv_sec) +
-    metil_time_microseconds_to_milliseconds(stopwatch->timeval.tv_usec)
+  return (
+    metil_time_milliseconds_get() -
+    (
+      metil_time_seconds_to_milliseconds(
+        metil_stopwatch->timeval.tv_sec
+      ) +
+      metil_time_microseconds_to_milliseconds(
+        metil_stopwatch->timeval.tv_usec
+      )
+    )
   );
 }


### PR DESCRIPTION
adds a scrolling menu item type
fixes a bug where menu items not marked as an action of select could be selected