### PR TITLE
[enh] `metil_texture_concrete`::add

### DIFF
--- a/include/metil_texture/metil_texture_concrete.h
+++ b/include/metil_texture/metil_texture_concrete.h
@@ -1,0 +1,24 @@
+#ifndef __metil_texture_metil_texture_concrete_h
+#define __metil_texture_metil_texture_concrete_h
+
+#include <math_c_vector.h>
+
+#include <Metal/MTLDevice.h>
+#include <Metal/MTLTexture.h>
+
+id<MTLTexture> _Nonnull metil_texture_concrete_generate(
+  struct math_c_vector2_unsigned_short_int,
+  unsigned char* _Nonnull,
+  unsigned int,
+  id<MTLDevice> _Nonnull
+);
+
+id<MTLTexture> _Nonnull metil_texture_concrete_secondary_generate(
+  struct math_c_vector2_unsigned_short_int,
+  unsigned char* _Nonnull,
+  unsigned int,
+  id<MTLDevice> _Nonnull
+);
+
+
+#endif

--- a/sources/metil_texture/metil_texture_concrete.m
+++ b/sources/metil_texture/metil_texture_concrete.m
@@ -1,0 +1,631 @@
+#include <metil_texture/metil_texture_concrete.h>
+
+#include <math_c_vector.h>
+
+#include <Metal/MTLDevice.h>
+#include <Metal/MTLTexture.h>
+
+id<MTLTexture> metil_texture_concrete_generate(
+  struct math_c_vector2_unsigned_short_int size,
+  unsigned char* seed,
+  unsigned int length_seed,
+  id<MTLDevice> metal_device
+) {
+  MTLTextureDescriptor* texture_descriptor = [
+    [
+      MTLTextureDescriptor
+      alloc
+    ]
+    init
+  ];
+
+  texture_descriptor.pixelFormat = (
+    MTLPixelFormatRGBA8Unorm
+  );
+
+  texture_descriptor.width = (
+    size.x
+  );
+
+  texture_descriptor.height = (
+    size.y
+  );
+
+  static id<MTLTexture> texture;
+  texture = [
+    metal_device
+    newTextureWithDescriptor: texture_descriptor
+  ];
+
+  MTLRegion region = {
+    {0, 0, 0},
+    {texture_descriptor.width, texture_descriptor.height, 1}
+  };
+
+  unsigned int length_bytes_texture_row = (
+    4 *
+    texture_descriptor.width
+  );
+
+  unsigned int length_bytes_texture = (
+    length_bytes_texture_row *
+    texture_descriptor.height
+  );
+
+  unsigned char* pixel_bytes = (
+    malloc(
+      sizeof(
+        unsigned char
+      ) *
+      length_bytes_texture
+    )
+  );
+
+  unsigned char* pixel_bytes_secondary = (
+    malloc(
+      sizeof(
+        unsigned char
+      ) *
+      length_bytes_texture
+    )
+  );
+
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; ++index_x) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; ++index_y) { 
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    unsigned int r = ((index_x + 548) % 7) * ((index_y + 234) % 2) * 0x1b * seed[((index_x + 54) * (index_y + 13)) % length_seed];
+    pixel_bytes[index_pixel] = 0x7f + ((seed[r % length_seed] + 1) % 0x1b);
+    pixel_bytes[index_pixel + 1] = 0x7f + ((seed[(r) % length_seed] + 1) % 0x1b);
+    pixel_bytes[index_pixel + 2] = 0x7f + ((seed[(r) % length_seed] + 0) % 0x1b);
+    pixel_bytes[index_pixel + 3] = 0xff;
+  }}
+
+
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; index_x += 2) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; index_y += 2) {
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    pixel_bytes_secondary[index_pixel] = pixel_bytes[index_pixel];
+    pixel_bytes_secondary[index_pixel + 1] = pixel_bytes[index_pixel + 1];
+    pixel_bytes_secondary[index_pixel + 2] = pixel_bytes[index_pixel + 2];
+    pixel_bytes_secondary[index_pixel + 3] = 0xff;
+  }}
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; index_x += 1) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; index_y += 1) {
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    if (pixel_bytes_secondary[index_pixel] != 0) continue;
+
+    if (
+      index_x > 0
+    ) {
+      unsigned int z = (index_x - 1) * 4 + index_y * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+
+      if (
+        index_y > 0
+      ) {
+        unsigned int f = (index_x - 1) * 4 + (index_y - 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[f]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[f + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[f + 2]) / 2
+        );
+      }
+
+      if (
+        index_y < texture_descriptor.height - 1
+      ) {
+        unsigned int z = (index_x - 1) * 4 + (index_y + 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+        );
+      }
+    }
+
+    if (
+      index_x < texture_descriptor.width - 1
+    ) {
+      unsigned int z = (index_x + 1) * 4 + index_y * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+
+      if (
+        index_y > 0
+      ) {
+        unsigned int f = (index_x + 1) * 4 + (index_y - 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[f]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[f + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[f + 2]) / 2
+        );
+      }
+
+      if (
+        index_y < texture_descriptor.height - 1
+      ) {
+        unsigned int z = (index_x + 1) * 4 + (index_y + 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+        );
+      }
+    }
+
+    if (
+      index_y > 0
+    ) {
+      unsigned int z = index_x * 4 + (index_y - 1) * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+    }
+
+    if (
+      index_y < texture_descriptor.height - 1
+    ) {
+      unsigned int z = index_x * 4 + (index_y + 1) * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+    }
+
+    pixel_bytes_secondary[index_pixel + 3] = 0xff;
+  }}
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; ++index_x) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; ++index_y) {
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    pixel_bytes_secondary[index_pixel] = pixel_bytes_secondary[index_pixel] * ((pixel_bytes_secondary[index_pixel] - 0x7f) / 0x1b);
+    pixel_bytes_secondary[index_pixel + 1] = pixel_bytes_secondary[index_pixel + 1] * ((pixel_bytes_secondary[index_pixel + 1] - 0x7f) / 0x1b);
+    pixel_bytes_secondary[index_pixel + 2] = pixel_bytes_secondary[index_pixel + 2] * ((pixel_bytes_secondary[index_pixel + 2] - 0x7f) / 0x1b);
+    pixel_bytes_secondary[index_pixel + 3] = 0xff;
+  }}
+  for (unsigned int index_iteration = 0; index_iteration < 100; ++index_iteration) {
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; index_x += 2) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; index_y += 1) {
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+
+    if (
+      index_x > 0
+    ) {
+      unsigned int z = (index_x - 1) * 4 + index_y * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[z + 2]) / 2
+      );
+
+      if (
+        index_y > 0
+      ) {
+        unsigned int f = (index_x - 1) * 4 + (index_y - 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[f]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[f + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[f + 2]) / 2
+        );
+      }
+
+      if (
+        index_y < texture_descriptor.height - 1
+      ) {
+        unsigned int z = (index_x - 1) * 4 + (index_y + 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[z]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[z + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[z + 2]) / 2
+        );
+      }
+    }
+
+    if (
+      index_x < texture_descriptor.width - 1
+    ) {
+      unsigned int z = (index_x + 1) * 4 + index_y * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[z + 2]) / 2
+      );
+
+      if (
+        index_y > 0
+      ) {
+        unsigned int f = (index_x + 1) * 4 + (index_y - 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[f]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[f + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[f + 2]) / 2
+        );
+      }
+
+      if (
+        index_y < texture_descriptor.height - 1
+      ) {
+        unsigned int z = (index_x + 1) * 4 + (index_y + 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[z]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[z + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[z + 2]) / 2
+        );
+      }
+    }
+
+    if (
+      index_y > 0
+    ) {
+      unsigned int z = index_x * 4 + (index_y - 1) * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[z + 2]) / 2
+      );
+    }
+
+    if (
+      index_y < texture_descriptor.height - 1
+    ) {
+      unsigned int z = index_x * 4 + (index_y + 1) * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes_secondary[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes_secondary[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes_secondary[z + 2]) / 2
+      );
+    }
+  }}}
+
+  [
+    texture
+    replaceRegion: region
+    mipmapLevel: 0
+    withBytes: pixel_bytes
+    bytesPerRow: length_bytes_texture_row
+  ];
+
+  [
+    texture_descriptor
+    release
+  ];
+
+  free(
+    pixel_bytes
+  );
+
+  free(
+    pixel_bytes_secondary
+  );
+
+  return (
+    texture
+  );
+}
+
+
+id<MTLTexture> metil_texture_concrete_secondary_generate(
+  struct math_c_vector2_unsigned_short_int size,
+  unsigned char* seed,
+  unsigned int length_seed,
+  id<MTLDevice> metal_device
+) {
+  MTLTextureDescriptor* texture_descriptor = [
+    [
+      MTLTextureDescriptor
+      alloc
+    ]
+    init
+  ];
+
+  texture_descriptor.pixelFormat = (
+    MTLPixelFormatRGBA8Unorm
+  );
+
+  texture_descriptor.width = (
+    size.x
+  );
+
+  texture_descriptor.height = (
+    size.y
+  );
+
+  static id<MTLTexture> texture;
+  texture = [
+    metal_device
+    newTextureWithDescriptor: texture_descriptor
+  ];
+
+  MTLRegion region = {
+    {0, 0, 0},
+    {texture_descriptor.width, texture_descriptor.height, 1}
+  };
+
+  unsigned int length_bytes_texture_row = (
+    4 *
+    texture_descriptor.width
+  );
+
+  unsigned int length_bytes_texture = (
+    length_bytes_texture_row *
+    texture_descriptor.height
+  );
+
+  unsigned char* pixel_bytes = (
+    malloc(
+      sizeof(
+        unsigned char
+      ) *
+      length_bytes_texture
+    )
+  );
+
+  unsigned char* pixel_bytes_secondary = (
+    malloc(
+      sizeof(
+        unsigned char
+      ) *
+      length_bytes_texture
+    )
+  );
+
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; ++index_x) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; ++index_y) { 
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    unsigned int r = ((index_x + 0x0224) % 7) * ((index_y + 0xea) % 2) * 0x1b * seed[((index_x + 0x36) * (index_y + 0x0d)) % length_seed];
+    pixel_bytes[index_pixel] = 0x7f + ((seed[r % length_seed] + 1) % 0x1b);
+    pixel_bytes[index_pixel + 1] = 0x7f + ((seed[(r) % length_seed] + 1) % 0x1b);
+    pixel_bytes[index_pixel + 2] = 0x7f + ((seed[(r) % length_seed] + 0) % 0x1b);
+    pixel_bytes[index_pixel + 3] = 0xff;
+  }}
+  
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; index_x += 2) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; index_y += 2) {
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    pixel_bytes_secondary[index_pixel] = pixel_bytes[index_pixel];
+    pixel_bytes_secondary[index_pixel + 1] = pixel_bytes[index_pixel + 1];
+    pixel_bytes_secondary[index_pixel + 2] = pixel_bytes[index_pixel + 2];
+    pixel_bytes_secondary[index_pixel + 3] = 0xff;
+  }}
+  for (unsigned int index_x = 0; index_x < texture_descriptor.width; index_x += 1) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; index_y += 1) {
+    unsigned int index_pixel = index_x * 4 + index_y * texture_descriptor.width * 4;
+    if (pixel_bytes_secondary[index_pixel] != 0) continue;
+
+    if (
+      index_x > 0
+    ) {
+      unsigned int z = (index_x - 1) * 4 + index_y * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+
+      if (
+        index_y > 0
+      ) {
+        unsigned int f = (index_x - 1) * 4 + (index_y - 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[f]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[f + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[f + 2]) / 2
+        );
+      }
+
+      if (
+        index_y < texture_descriptor.height - 1
+      ) {
+        unsigned int z = (index_x - 1) * 4 + (index_y + 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+        );
+      }
+    }
+
+    if (
+      index_x < texture_descriptor.width - 1
+    ) {
+      unsigned int z = (index_x + 1) * 4 + index_y * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+
+      if (
+        index_y > 0
+      ) {
+        unsigned int f = (index_x + 1) * 4 + (index_y - 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[f]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[f + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[f + 2]) / 2
+        );
+      }
+
+      if (
+        index_y < texture_descriptor.height - 1
+      ) {
+        unsigned int z = (index_x + 1) * 4 + (index_y + 1) * texture_descriptor.width * 4;
+    
+        pixel_bytes_secondary[index_pixel] = (
+          (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 1] = (
+          (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+        );
+        pixel_bytes_secondary[index_pixel + 2] = (
+          (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+        );
+      }
+    }
+
+    if (
+      index_y > 0
+    ) {
+      unsigned int z = index_x * 4 + (index_y - 1) * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+    }
+
+    if (
+      index_y < texture_descriptor.height - 1
+    ) {
+      unsigned int z = index_x * 4 + (index_y + 1) * texture_descriptor.width * 4;
+
+      pixel_bytes_secondary[index_pixel] = (
+        (pixel_bytes_secondary[index_pixel] + pixel_bytes[z]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 1] = (
+        (pixel_bytes_secondary[index_pixel + 1] + pixel_bytes[z + 1]) / 2
+      );
+      pixel_bytes_secondary[index_pixel + 2] = (
+        (pixel_bytes_secondary[index_pixel + 2] + pixel_bytes[z + 2]) / 2
+      );
+    }
+
+    pixel_bytes_secondary[index_pixel + 3] = 0xff;
+  }}
+
+  [
+    texture
+    replaceRegion: region
+    mipmapLevel: 0
+    withBytes: pixel_bytes
+    bytesPerRow: length_bytes_texture_row
+  ];
+
+  [
+    texture_descriptor
+    release
+  ];
+
+  free(
+    pixel_bytes
+  );
+
+  free(
+    pixel_bytes_secondary
+  );
+
+  return (
+    texture
+  );
+}


### PR DESCRIPTION
this is a bit sloppy but the scripts were able to be converted using just a few find and replaces to convert over from js to c

generates concrete like material


## examples

- seed: `jhnqiriocehsda jdfsnf nf dsjaionaonuon8oe9iql3fewm,sm kx i,ce,njdaskljzljvslklhmmwngkxerksetmiunshng,comsjfdgkldjsgajsdfli ksm lfjg,seov,merldjilsdmfigojfksoke,rscgj,omem seflijmj,ocemrjfkgwmlbsekotjnmeo9fidj,lecmorogjbijfvjjvjomiosmlog sgkifp jldofbjismdrlg,obmsgjlvdg,rjmfslgbekjrhk8t843877347583u9t4u63545hghjerigjroeifgiijh9mw8bho8954tu593874767573475366748568994860450946043958740693804050686495986848659868905456968458096548 e94s 8vostcgju8e8rmrxobklilwjelse85vj9btsmev5uocijrsmg9wlv8oe4bsukrtjvmgncl9mw8imbdx8oeomrsljtnobirewtv.j,cgm58reg5ut98mrteoyv4i5rjtubjy9v,jo8ehijucm6,lt8euhlbc48o6iel8mo6irtuy8mom5ei,buvryhvoejlr95cjgem985985emtjpsu948ocwusnetl9em4ubjl8ev5l6c,o948gl5ocfen.9..iebyj,8v5hel4ceo,l58rujvm8onm4umbe8dory9tjiuyjkoelr9otuh9fiytnj865nork48ej5rbe86,emj;kv59gv,e5yirpbt9;,yebirpt,9vyipert89kl4,gueo45m7d8siowhn74ncir8wb34un985uvw348wcuwltcjkt,j4mme8mubtjgjvej8vem5cuthgoelnm4g578inr,uvw4mjes84cmgen4l958xw4dhmtwj839u4heojtw89gto3iurn3rnvwjo9834meuwej5rtkw8347lij8roteucimg859wxo`
- length_seed: 1000

mess around with the repeat amounts 

```metal
constexpr metal::sampler sampler_texture(
  metal::t_address::repeat,
  metal::r_address::repeat,
  metal::s_address::repeat
);

float4 color_texture = float4(
  texture.sample(
    sampler_texture,
    data_vertex.position_texture / 1000.0f
  )
);
```

is zoomed way in and

```metal
constexpr metal::sampler sampler_texture(
  metal::t_address::repeat,
  metal::r_address::repeat,
  metal::s_address::repeat
);

float4 color_texture = float4(
  texture.sample(
    sampler_texture,
    data_vertex.position_texture * 1000.0f
  )
);
```

is zoomed way out


add variations to it, add depth, etc. it's meant to be toyed with to suit your needs
<img width="395" height="257" alt="Screenshot 2026-01-13 at 14 03 50 1" src="https://github.com/user-attachments/assets/7d842abb-2e29-43b7-8a23-e29795a87c98" />
<img width="1920" height="1243" alt="Screenshot 2026-01-13 at 14 03 50" src="https://github.com/user-attachments/assets/bf6ff670-3921-4870-8233-678f892ef835" />
<img width="1460" height="903" alt="Screenshot 2026-01-13 at 14 03 58" src="https://github.com/user-attachments/assets/65498d74-72e7-4135-8f76-e702236b4457" />
<img width="1232" height="620" alt="Screenshot 2026-01-13 at 14 04 07" src="https://github.com/user-attachments/assets/fcac9312-57ae-47f5-b95a-057ff2cc5e90" />
<img width="1123" height="780" alt="Screenshot 2026-01-13 at 14 04 20" src="https://github.com/user-attachments/assets/eea35831-0fde-4565-ac7b-928d629945ee" />
<img width="1221" height="797" alt="Screenshot 2026-01-13 at 14 04 35" src="https://github.com/user-attachments/assets/29fd52ea-aafc-449d-b58e-ecb57f0dc9f7" />
<img width="1198" height="979" alt="Screenshot 2026-01-13 at 14 04 49" src="https://github.com/user-attachments/assets/9b4b2ea6-aac6-4e8e-b546-d17cc3a49d5d" />
<img width="1096" height="670" alt="Screenshot 2026-01-13 at 14 07 34" src="https://github.com/user-attachments/assets/3b820b77-8097-497a-bf95-3df9942a72a0" />
<img width="814" height="500" alt="Screenshot 2026-01-13 at 14 07 43" src="https://github.com/user-attachments/assets/3ea43cdc-cc43-4dd1-a518-876573526d24" />
<img width="824" height="620" alt="Screenshot 2026-01-13 at 14 08 04" src="https://github.com/user-attachments/assets/60c60a58-40a4-4c4e-a561-498df73892fa" />
<img width="508" height="551" alt="Screenshot 2026-01-13 at 14 08 19" src="https://github.com/user-attachments/assets/fcaf4e74-f39b-4a6b-89a3-d4686853fbf8" />
<img width="1032" height="1055" alt="Screenshot 2026-01-13 at 14 08 28" src="https://github.com/user-attachments/assets/db9a1554-9da0-4f48-a833-cb19cdbdeb25" />
<img width="825" height="551" alt="Screenshot 2026-01-13 at 14 08 48" src="https://github.com/user-attachments/assets/0f4b90eb-8b03-4ba1-bdac-02b81ea2fd7d" />
<img width="715" height="334" alt="Screenshot 2026-01-13 at 14 09 08" src="https://github.com/user-attachments/assets/dc4bfeab-c642-44f5-b3df-e151b1fdb689" />
<img width="985" height="893" alt="Screenshot 2026-01-13 at 14 09 17" src="https://github.com/user-attachments/assets/9ae014d2-8598-44c5-b188-7f5bf4170806" />
<img width="868" height="581" alt="Screenshot 2026-01-13 at 14 09 24" src="https://github.com/user-attachments/assets/9227b3c1-7d7e-44bd-a510-34f7f1f95cc6" />
<img width="800" height="848" alt="Screenshot 2026-01-13 at 14 09 36" src="https://github.com/user-attachments/assets/3c70f157-0f36-4fe5-bbff-6ec5e783cf09" />
<img width="1012" height="920" alt="Screenshot 2026-01-13 at 14 09 41" src="https://github.com/user-attachments/assets/9ef92c51-98ae-4ef9-ad45-f07cb5b13117" />
<img width="1306" height="903" alt="Screenshot 2026-01-13 at 14 10 01" src="https://github.com/user-attachments/assets/19f81756-40fe-4a40-8fb7-ba29aa3f08ef" />
<img width="994" height="734" alt="Screenshot 2026-01-13 at 14 11 10" src="https://github.com/user-attachments/assets/5fe8a720-2c09-4c11-9f50-57a1eb175b4f" />
<img width="1920" height="1243" alt="Screenshot 2026-01-13 at 14 11 21" src="https://github.com/user-attachments/assets/15be1336-d43a-4ac4-9db9-aebbd80ff161" />
<img width="971" height="623" alt="Screenshot 2026-01-13 at 14 11 22" src="https://github.com/user-attachments/assets/e7aca951-a6fc-4da6-a15a-f6423e4ec3fd" />


## challenge

find the original seed to this image :)

https://github.com/alic3dev/c938/pull/92#issuecomment-3742924461
