### PR TITLE
[dev] remove->{`sizeof(char)`}

### DIFF
--- a/examples/collision/sources/example_collision_scene.m
+++ b/examples/collision/sources/example_collision_scene.m
@@ -583,9 +583,6 @@ void example_collision_scene_initialize(
 
   clic3_memory_allocate(
     &pixel_bytes,
-    sizeof(
-      unsigned char
-    ) *
     length_bytes_texture
   );
 

--- a/examples/model/sources/example_model_scene.m
+++ b/examples/model/sources/example_model_scene.m
@@ -151,7 +151,9 @@ void example_model_scene_initialize(
   clic3_memory_allocate(
     &metil_mesh->vertices,
     (
-      sizeof(struct math_c_vector4_float) *
+      sizeof(
+        struct math_c_vector4_float
+      ) *
       metil_mesh->length_vertices
     )
   );

--- a/readme.md
+++ b/readme.md
@@ -930,7 +930,9 @@ OSStatus io_proc(
 
     unsigned long int size_buffer_out = (
       audio_buffer_current.mDataByteSize /
-      sizeof(float)
+      sizeof(
+        float
+      )
     );
 
     unsigned long int count_channel_out = (

--- a/sources/metil_audio/metil_audio_io_proc_macos.m
+++ b/sources/metil_audio/metil_audio_io_proc_macos.m
@@ -42,7 +42,9 @@ OSStatus metil_audio_output_io_proc(
 
       unsigned long int size_buffer_out = (
         audio_buffer_current.mDataByteSize /
-        sizeof(float)
+        sizeof(
+          float
+        )
       );
 
       for (
@@ -113,7 +115,9 @@ OSStatus metil_audio_output_io_proc(
 
     unsigned long int size_buffer_out = (
       audio_buffer_current.mDataByteSize /
-      sizeof(float)
+      sizeof(
+        float
+      )
     );
 
     for (

--- a/sources/metil_group.m
+++ b/sources/metil_group.m
@@ -268,7 +268,9 @@ void metil_group_destroy_renderable_at_index(
   clic3_memory_allocate(
     &metil_group->renderables,
     (
-      sizeof(struct metil_renderable*) *
+      sizeof(
+        struct metil_renderable*
+      ) *
       metil_group->length
     ) 
   );

--- a/sources/metil_model/metil_model.m
+++ b/sources/metil_model/metil_model.m
@@ -250,10 +250,13 @@ void metil_model_buffers_initialize(
   metil_model->buffer_joints = [
     metal_device
     newBufferWithLength: (
-      sizeof(struct math_c_vector3_float) * (
+      sizeof(
+        struct math_c_vector3_float
+      ) * (
         metil_model->length_joints +
         1
-      ) * 3
+      ) *
+      3
     )
     options: MTLResourceStorageModeShared
   ];
@@ -310,7 +313,9 @@ void metil_model_buffers_initialize(
     metil_object_buffers_initialize_with_data_size(
       metil_object,
       metal_device,
-      sizeof(struct metil_renderer_data_model_object)
+      sizeof(
+        struct metil_renderer_data_model_object
+      )
     );
 
     metil_object_buffers_add(
@@ -334,7 +339,9 @@ void metil_model_buffers_initialize(
         ]
       )
       length: (
-        sizeof(unsigned int) *
+        sizeof(
+          unsigned int
+        ) *
         metil_object->mesh.length_vertices
       )
       options: MTLResourceStorageModePrivate

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -174,7 +174,11 @@
     data_buffer_frame[
       index_buffer
     ] = [self->metil->renderer_interface.metal_device
-      newBufferWithLength: sizeof(struct metil_renderer_data_frame)
+      newBufferWithLength: (
+        sizeof(
+          struct metil_renderer_data_frame
+        )
+      )
       options: MTLResourceStorageModeShared
     ];
   }

--- a/sources/metil_system_information.c
+++ b/sources/metil_system_information.c
@@ -10,16 +10,22 @@ void metil_system_information_initialize(
   struct metil_configuration* metil_configuration
 ) {
   unsigned int count_cores_cpu;
-  unsigned long length_count_cores_cpu = sizeof(unsigned int);
+  unsigned long length_count_cores_cpu = (
+    sizeof(
+      unsigned int
+    )
+  );
   
   metil_system_information->cores_cpu = 1;
 
-  int status_core_count = sysctlbyname(
-    "hw.ncpu",
-    &count_cores_cpu,
-    &length_count_cores_cpu,
-    0,
-    0
+  int status_core_count = (
+    sysctlbyname(
+      "hw.ncpu",
+      &count_cores_cpu,
+      &length_count_cores_cpu,
+      0,
+      0
+    )
   );
 
   if (

--- a/sources/metil_text/metil_text.m
+++ b/sources/metil_text/metil_text.m
@@ -185,12 +185,7 @@ struct metil_text_image* metil_text_render(
 
   clic3_memory_allocate(
     &text_image->data,
-    (
-      sizeof(
-        unsigned char
-      ) *
-      length_text_image_data
-    )
+    length_text_image_data
   );
 
   for (

--- a/sources/metil_text/metil_text_characters.m
+++ b/sources/metil_text/metil_text_characters.m
@@ -102,10 +102,18 @@ void metil_text_characters_initialize(
     metil_text_characters_default->vertices[
       index_character
     ] = [metal_device
-      newBufferWithBytes: metil_text_characters_default->meshes[index_character].vertices
+      newBufferWithBytes: (
+        metil_text_characters_default->meshes[
+          index_character
+        ].vertices
+      )
       length: (
-        metil_text_characters_default->meshes[index_character].length_vertices *
-        sizeof(struct math_c_vector4_float)
+        metil_text_characters_default->meshes[
+          index_character
+        ].length_vertices *
+        sizeof(
+          struct math_c_vector4_float
+        )
       )
       options: MTLResourceStorageModeShared
     ];
@@ -114,7 +122,9 @@ void metil_text_characters_initialize(
   metil_text_characters_default->indices = [metal_device
     newBufferWithBytes: metil_text_characters_default->meshes[0].indices
     length: (
-      sizeof(unsigned int) *
+      sizeof(
+        unsigned int
+      ) *
       metil_text_characters_default->meshes[0].length_indices
     )
     options: MTLResourceStorageModeShared

--- a/sources/metil_texture/metil_texture_concrete.m
+++ b/sources/metil_texture/metil_texture_concrete.m
@@ -438,22 +438,12 @@ id<MTLTexture> metil_texture_concrete_secondary_generate(
 
   clic3_memory_allocate(
     &pixel_bytes,
-    (
-      sizeof(
-        unsigned char
-      ) *
-      length_bytes_texture
-    )
+    length_bytes_texture
   );
 
   clic3_memory_allocate(
     &pixel_bytes_secondary,
-    (
-      sizeof(
-        unsigned char
-      ) *
-      length_bytes_texture
-    )
+    length_bytes_texture
   );
 
   for (unsigned int index_x = 0; index_x < texture_descriptor.width; ++index_x) { for (unsigned int index_y = 0; index_y < texture_descriptor.height; ++index_y) { 


### PR DESCRIPTION
a `char` and `unsigned char` are always `1` byte, no need to size them