### PR TITLE
[enh] `color`->`colour`::use_correct_spelling

### DIFF
--- a/examples/2d_rendering/sources/example_2d_scene.m
+++ b/examples/2d_rendering/sources/example_2d_scene.m
@@ -62,22 +62,22 @@ void example_2d_scene_initialize(
       ].buffer.contents
     );
 
-    data_object->color.x = (
+    data_object->colour.x = (
       (float) index_renderable /
       (scene->length_renderables - 1)
     );
 
-    data_object->color.y = (
+    data_object->colour.y = (
       (float) ((index_renderable + 33) % scene->length_renderables) /
       (scene->length_renderables - 1)
     );
 
-    data_object->color.z = (
+    data_object->colour.z = (
       (float) ((index_renderable + 66) % scene->length_renderables) /
       (scene->length_renderables - 1)
     );
 
-    data_object->color.w = 1.0f;
+    data_object->colour.w = 1.0f;
 
     object->position.x = (
       (float) (index_renderable % 10)
@@ -123,21 +123,21 @@ void example_2d_scene_poll(
       .z = scene->time + (index_renderable + 1) * 10
     };
 
-    data_object->color.x = (
+    data_object->colour.x = (
       ((time_offset.x / 1000) % 2 == 0
         ? (float) (time_offset.x % 1000) / 1500.0f
         : (float) (1000 - (time_offset.x % 1000)) / 1500.0f
       ) +
       brightness_minimum
     );
-    data_object->color.y = (
+    data_object->colour.y = (
       ((time_offset.y / 1000) % 2 == 0
         ? (float) (time_offset.y % 1000) / 1500.0f
         : (float) (1000 - (time_offset.y % 1000)) / 1500.0f
       ) +
       brightness_minimum
     );
-    data_object->color.z = (
+    data_object->colour.z = (
       ((time_offset.z / 1000) % 2 == 0
         ? (float) (time_offset.z % 1000) / 1500.0f
         : (float) (1000 - (time_offset.z % 1000)) / 1500.0f

--- a/examples/3d_rendering/sources/example_3d_scene.m
+++ b/examples/3d_rendering/sources/example_3d_scene.m
@@ -76,16 +76,16 @@ void example_3d_scene_initialize(
       ].buffer.contents
     );
 
-    data_object->color.x = (
+    data_object->colour.x = (
       (float) (index_renderable % 10) / 10.0f
     );
-    data_object->color.y = (
+    data_object->colour.y = (
       (float) ((index_renderable + 3) % 10) / 10.0f
     );
-    data_object->color.z = (
+    data_object->colour.z = (
       (float) ((index_renderable + 5) % 10) / 10.0f
     );
-    data_object->color.w = 1.0f;
+    data_object->colour.w = 1.0f;
   }
 
   for (
@@ -291,16 +291,16 @@ void example_3d_scene_initialize(
       ].buffer.contents
     );
 
-    data_object->color.x = (
+    data_object->colour.x = (
       (float) (index_renderable % 10) / 10.0f
     );
-    data_object->color.y = (
+    data_object->colour.y = (
       (float) ((index_renderable * 3) % 10) / 10.0f
     );
-    data_object->color.z = (
+    data_object->colour.z = (
       (float) ((index_renderable * 5) % 10) / 10.0f
     );
-    data_object->color.w = 1.0f;
+    data_object->colour.w = 1.0f;
   }
 }
 
@@ -313,7 +313,7 @@ void example_3d_scene_poll(
     scene
   );
 
-  float color_shift = (
+  float colour_shift = (
     scene->player.position.x +
     scene->player.position.y +
     scene->player.position.z +
@@ -356,10 +356,10 @@ void example_3d_scene_poll(
       ].buffer.contents
     );
 
-    data_object->color.x = (float) (index_renderable % 10) / 10.0f + color_shift;
-    data_object->color.y = (float) ((index_renderable * 3) % 10) / 10.0f + color_shift;
-    data_object->color.z = (float) ((index_renderable * 5) % 10) / 10.0f + color_shift;
+    data_object->colour.x = (float) (index_renderable % 10) / 10.0f + colour_shift;
+    data_object->colour.y = (float) ((index_renderable * 3) % 10) / 10.0f + colour_shift;
+    data_object->colour.z = (float) ((index_renderable * 5) % 10) / 10.0f + colour_shift;
 
-    data_object->color.w = 1.0f;
+    data_object->colour.w = 1.0f;
   }
 }

--- a/examples/collision/metal/floor.metal
+++ b/examples/collision/metal/floor.metal
@@ -5,7 +5,7 @@
 struct data_vertex {
   float4 position [[position]];
   float point_size [[point_size]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex floor_vertex(
@@ -45,11 +45,11 @@ struct data_vertex {
     )
   );
 
-  data_vertex.color = float4(
-    data_object->color.x * multiplier,
-    data_object->color.y * multiplier,
-    data_object->color.z * multiplier,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x * multiplier,
+    data_object->colour.y * multiplier,
+    data_object->colour.z * multiplier,
+    data_object->colour.w
   );
 
   return data_vertex;
@@ -58,5 +58,5 @@ struct data_vertex {
 [[fragment]] float4 floor_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/collision/metal/projectile.metal
+++ b/examples/collision/metal/projectile.metal
@@ -5,7 +5,7 @@
 struct data_vertex {
   float4 position [[position]];
   float point_size [[point_size]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex projectile_vertex(
@@ -35,7 +35,7 @@ struct data_vertex {
     ]
   );
 
-  data_vertex.color = float4(
+  data_vertex.colour = float4(
     id_vertex > 50,
     0.0f,
     0.0f,
@@ -54,5 +54,5 @@ struct data_vertex {
 [[fragment]] float4 projectile_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/collision/metal/target.metal
+++ b/examples/collision/metal/target.metal
@@ -5,7 +5,7 @@
 struct data_vertex {
   float4 position [[position]];
   float point_size [[point_size]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex target_vertex(
@@ -38,11 +38,11 @@ struct data_vertex {
     10.0f
   );
 
-  data_vertex.color = float4(
-    metal::fmod(data_object->color.x + offset, 1.0f),
-    metal::fmod(data_object->color.y + offset, 1.0f),
-    metal::fmod(data_object->color.z + offset, 1.0f),
-    data_object->color.w
+  data_vertex.colour = float4(
+    metal::fmod(data_object->colour.x + offset, 1.0f),
+    metal::fmod(data_object->colour.y + offset, 1.0f),
+    metal::fmod(data_object->colour.z + offset, 1.0f),
+    data_object->colour.w
   );
 
   return data_vertex;
@@ -51,5 +51,5 @@ struct data_vertex {
 [[fragment]] float4 target_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/collision/metal/turret.metal
+++ b/examples/collision/metal/turret.metal
@@ -8,7 +8,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
   float2 position_texture;
 };
 
@@ -69,11 +69,11 @@ struct data_vertex {
     )
   );
 
-  data_vertex.color = float4(
-    data_object->color.x * brightness,
-    data_object->color.y * brightness,
-    data_object->color.z * brightness,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x * brightness,
+    data_object->colour.y * brightness,
+    data_object->colour.z * brightness,
+    data_object->colour.w
   );
 
   data_vertex.position_texture.x = (
@@ -103,7 +103,7 @@ struct data_vertex {
     metal::s_address::repeat
   );
 
-  float4 texture_color = float4(
+  float4 texture_colour = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture * 12.45f
@@ -111,9 +111,9 @@ struct data_vertex {
   );
 
   return float4(
-    texture_color.r * data_vertex.color.r,
-    texture_color.g * data_vertex.color.g,
-    texture_color.b * data_vertex.color.b,
-    texture_color.a * data_vertex.color.a
+    texture_colour.r * data_vertex.colour.r,
+    texture_colour.g * data_vertex.colour.g,
+    texture_colour.b * data_vertex.colour.b,
+    texture_colour.a * data_vertex.colour.a
   );
 }

--- a/examples/collision/metal/turret_barrel.metal
+++ b/examples/collision/metal/turret_barrel.metal
@@ -8,7 +8,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
   float2 position_texture;
 };
 
@@ -70,11 +70,11 @@ struct data_vertex {
     ].y / 0.5f + 0.5f)
   );
 
-  data_vertex.color = float4(
-    data_object->color.x * brightness,
-    data_object->color.y * brightness,
-    data_object->color.z * brightness,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x * brightness,
+    data_object->colour.y * brightness,
+    data_object->colour.z * brightness,
+    data_object->colour.w
   );
 
   data_vertex.position_texture.x = (
@@ -104,7 +104,7 @@ struct data_vertex {
     metal::s_address::repeat
   );
 
-  float4 texture_color = float4(
+  float4 texture_colour = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture * 100.01f
@@ -112,9 +112,9 @@ struct data_vertex {
   );
 
   return float4(
-    texture_color.r * data_vertex.color.r,
-    texture_color.g * data_vertex.color.g,
-    texture_color.b * data_vertex.color.b,
-    texture_color.a * data_vertex.color.a
+    texture_colour.r * data_vertex.colour.r,
+    texture_colour.g * data_vertex.colour.g,
+    texture_colour.b * data_vertex.colour.b,
+    texture_colour.a * data_vertex.colour.a
   );
 }

--- a/examples/collision/metal/turret_sight.metal
+++ b/examples/collision/metal/turret_sight.metal
@@ -8,7 +8,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
   float2 position_texture;
 };
 
@@ -59,11 +59,11 @@ struct data_vertex {
     position_vertex
   );
 
-  data_vertex.color = float4(
-    data_object->color.x,
-    data_object->color.y,
-    data_object->color.z,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x,
+    data_object->colour.y,
+    data_object->colour.z,
+    data_object->colour.w
   );
 
   data_vertex.position_texture.x = (
@@ -93,7 +93,7 @@ struct data_vertex {
     metal::s_address::repeat
   );
 
-  float4 texture_color = float4(
+  float4 texture_colour = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture
@@ -101,9 +101,9 @@ struct data_vertex {
   );
 
   return float4(
-    texture_color.r * data_vertex.color.r,
-    texture_color.g * data_vertex.color.g,
-    texture_color.b * data_vertex.color.b,
-    texture_color.a * data_vertex.color.a
+    texture_colour.r * data_vertex.colour.r,
+    texture_colour.g * data_vertex.colour.g,
+    texture_colour.b * data_vertex.colour.b,
+    texture_colour.a * data_vertex.colour.a
   );
 }

--- a/examples/collision/sources/models/turret.m
+++ b/examples/collision/sources/models/turret.m
@@ -248,64 +248,64 @@ void model_turret_initialize(
     ].buffer.contents
   );
 
-  renderer_data_object_turret_leg_one->color.x = 0.05f;
-  renderer_data_object_turret_leg_one->color.y = 0.05f;
-  renderer_data_object_turret_leg_one->color.z = 0.05f;
-  renderer_data_object_turret_leg_one->color.w = 1.0f;
+  renderer_data_object_turret_leg_one->colour.x = 0.05f;
+  renderer_data_object_turret_leg_one->colour.y = 0.05f;
+  renderer_data_object_turret_leg_one->colour.z = 0.05f;
+  renderer_data_object_turret_leg_one->colour.w = 1.0f;
 
-  renderer_data_object_turret_leg_two->color.x = (
-    renderer_data_object_turret_leg_one->color.x
+  renderer_data_object_turret_leg_two->colour.x = (
+    renderer_data_object_turret_leg_one->colour.x
   );
-  renderer_data_object_turret_leg_two->color.y = (
-    renderer_data_object_turret_leg_one->color.y
+  renderer_data_object_turret_leg_two->colour.y = (
+    renderer_data_object_turret_leg_one->colour.y
   );
-  renderer_data_object_turret_leg_two->color.z = (
-    renderer_data_object_turret_leg_one->color.z
+  renderer_data_object_turret_leg_two->colour.z = (
+    renderer_data_object_turret_leg_one->colour.z
   );
-  renderer_data_object_turret_leg_two->color.w = (
-    renderer_data_object_turret_leg_one->color.w
-  );
-
-  renderer_data_object_turret_leg_three->color.x = (
-    renderer_data_object_turret_leg_one->color.x
-  );
-  renderer_data_object_turret_leg_three->color.y = (
-    renderer_data_object_turret_leg_one->color.y
-  );
-  renderer_data_object_turret_leg_three->color.z = (
-    renderer_data_object_turret_leg_one->color.z
-  );
-  renderer_data_object_turret_leg_three->color.w = (
-    renderer_data_object_turret_leg_one->color.w
+  renderer_data_object_turret_leg_two->colour.w = (
+    renderer_data_object_turret_leg_one->colour.w
   );
 
-  renderer_data_object_turret_leg_four->color.x = (
-    renderer_data_object_turret_leg_one->color.x
+  renderer_data_object_turret_leg_three->colour.x = (
+    renderer_data_object_turret_leg_one->colour.x
   );
-  renderer_data_object_turret_leg_four->color.y = (
-    renderer_data_object_turret_leg_one->color.y
+  renderer_data_object_turret_leg_three->colour.y = (
+    renderer_data_object_turret_leg_one->colour.y
   );
-  renderer_data_object_turret_leg_four->color.z = (
-    renderer_data_object_turret_leg_one->color.z
+  renderer_data_object_turret_leg_three->colour.z = (
+    renderer_data_object_turret_leg_one->colour.z
   );
-  renderer_data_object_turret_leg_four->color.w = (
-    renderer_data_object_turret_leg_one->color.w
+  renderer_data_object_turret_leg_three->colour.w = (
+    renderer_data_object_turret_leg_one->colour.w
   );
 
-  renderer_data_object_turret_box->color.x = 0.05f;
-  renderer_data_object_turret_box->color.y = 0.05f;
-  renderer_data_object_turret_box->color.z = 0.05f;
-  renderer_data_object_turret_box->color.w = 1.0f;
+  renderer_data_object_turret_leg_four->colour.x = (
+    renderer_data_object_turret_leg_one->colour.x
+  );
+  renderer_data_object_turret_leg_four->colour.y = (
+    renderer_data_object_turret_leg_one->colour.y
+  );
+  renderer_data_object_turret_leg_four->colour.z = (
+    renderer_data_object_turret_leg_one->colour.z
+  );
+  renderer_data_object_turret_leg_four->colour.w = (
+    renderer_data_object_turret_leg_one->colour.w
+  );
 
-  renderer_data_object_turret_barrel->color.x = 0.05f;
-  renderer_data_object_turret_barrel->color.y = 0.05f;
-  renderer_data_object_turret_barrel->color.z = 0.05f;
-  renderer_data_object_turret_barrel->color.w = 1.0f;
+  renderer_data_object_turret_box->colour.x = 0.05f;
+  renderer_data_object_turret_box->colour.y = 0.05f;
+  renderer_data_object_turret_box->colour.z = 0.05f;
+  renderer_data_object_turret_box->colour.w = 1.0f;
 
-  renderer_data_object_turret_sight->color.x = 1.0f;
-  renderer_data_object_turret_sight->color.y = 1.0f;
-  renderer_data_object_turret_sight->color.z = 1.0f;
-  renderer_data_object_turret_sight->color.w = 1.0f;
+  renderer_data_object_turret_barrel->colour.x = 0.05f;
+  renderer_data_object_turret_barrel->colour.y = 0.05f;
+  renderer_data_object_turret_barrel->colour.z = 0.05f;
+  renderer_data_object_turret_barrel->colour.w = 1.0f;
+
+  renderer_data_object_turret_sight->colour.x = 1.0f;
+  renderer_data_object_turret_sight->colour.y = 1.0f;
+  renderer_data_object_turret_sight->colour.z = 1.0f;
+  renderer_data_object_turret_sight->colour.w = 1.0f;
 
   object_turret_barrel->index_pipeline_render = (
     example_collision_pipeline_index_turret_barrel

--- a/examples/face/include/example_face_renderer_data_object.h
+++ b/examples/face/include/example_face_renderer_data_object.h
@@ -10,7 +10,7 @@ struct example_face_renderer_data_object {
   struct math_c_vector3_float position;
   struct math_c_vector3_float size;
 
-  struct math_c_vector4_float color;
+  struct math_c_vector4_float colour;
 
   unsigned int vertex_hovered;
   unsigned int vertex_held;

--- a/examples/face/metal/face.metal
+++ b/examples/face/metal/face.metal
@@ -5,7 +5,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex face_vertex(
@@ -70,7 +70,7 @@ struct data_vertex {
     0.2
   ) / 0.5f);
 
-  data_vertex.color = float4(
+  data_vertex.colour = float4(
     1.0f * brightness,
     0.98f * brightness,
     0.9f * brightness,
@@ -83,5 +83,5 @@ struct data_vertex {
 [[fragment]] float4 face_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/face/metal/face_points.metal
+++ b/examples/face/metal/face_points.metal
@@ -6,7 +6,7 @@
 struct data_vertex {
   float4 position [[position]];
   float point_size [[point_size]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex face_points_vertex(
@@ -37,7 +37,7 @@ struct data_vertex {
   if (
     id_vertex + 1 == data_object->vertex_held
   ) {
-    data_vertex.color = float4(
+    data_vertex.colour = float4(
       0.0f,
       0.0f,
       1.0f,
@@ -48,7 +48,7 @@ struct data_vertex {
   } else if (
     id_vertex + 1 == data_object->vertex_hovered
   ) {
-    data_vertex.color = float4(
+    data_vertex.colour = float4(
       1.0f,
       0.0f,
       1.0f,
@@ -57,7 +57,7 @@ struct data_vertex {
 
     data_vertex.point_size = 10.0f;
   } else {
-    data_vertex.color = float4(
+    data_vertex.colour = float4(
       1.0f,
       1.0f,
       1.0f,
@@ -73,5 +73,5 @@ struct data_vertex {
 [[fragment]] float4 face_points_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/fog/metal/fog.metal
+++ b/examples/fog/metal/fog.metal
@@ -6,7 +6,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
   float brightness;
 };
 
@@ -35,11 +35,11 @@ struct data_vertex {
     vertices[id_vertex]
   );
 
-  data_vertex.color = float4(
-    data_object->color.x,
-    data_object->color.y,
-    data_object->color.z,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x,
+    data_object->colour.y,
+    data_object->colour.z,
+    data_object->colour.w
   );
 
   data_vertex.brightness = data_frame->brightness;
@@ -51,9 +51,9 @@ struct data_vertex {
   struct data_vertex data_vertex [[stage_in]]
 ) {
   return float4(
-    data_vertex.color.r * data_vertex.brightness,
-    data_vertex.color.g * data_vertex.brightness,
-    data_vertex.color.b * data_vertex.brightness,
-    data_vertex.color.a
+    data_vertex.colour.r * data_vertex.brightness,
+    data_vertex.colour.g * data_vertex.brightness,
+    data_vertex.colour.b * data_vertex.brightness,
+    data_vertex.colour.a
   );
 }

--- a/examples/fog/metal/fog_object.metal
+++ b/examples/fog/metal/fog_object.metal
@@ -6,7 +6,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
   float brightness;
   float distance;
 };
@@ -36,29 +36,29 @@ struct data_vertex {
     vertices[id_vertex]
   );
 
-  data_vertex.color = float4(
+  data_vertex.colour = float4(
     metal::fmod(
-      data_object->color.x * (float) (
+      data_object->colour.x * (float) (
         id_vertex +
         4234.23842398
       ),
       1.0f
     ),
     metal::fmod(
-      data_object->color.y * (float) (
+      data_object->colour.y * (float) (
         id_vertex +
         1489.8924489
       ),
       1.0f
     ),
     metal::fmod(
-      data_object->color.z * (float) (
+      data_object->colour.z * (float) (
         id_vertex +
         1.3892810472
       ),
       1.0f
     ),
-    data_object->color.w
+    data_object->colour.w
   );
 
   data_vertex.brightness = (
@@ -85,7 +85,7 @@ struct data_vertex {
 }
 
 float4 fog_apply(
-  float4 color,
+  float4 colour,
   float distance
 ) {
   float distance_offset = metal::fmin(
@@ -113,43 +113,43 @@ float4 fog_apply(
   return float4(
     metal::fmin(
       (
-        color.r +
+        colour.r +
         fog_thickness
       ),
       1.0f
     ),
     metal::fmin(
       (
-        color.g +
+        colour.g +
         fog_thickness
       ),
       1.0f
     ),
     metal::fmin(
       (
-        color.b +
+        colour.b +
         fog_thickness
       ),
       1.0f
     ),
-    color.a
+    colour.a
   );
 }
 
 [[fragment]] float4 fog_object_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  float4 color_lighted = float4(
-    data_vertex.color.r * data_vertex.brightness,
-    data_vertex.color.g * data_vertex.brightness,
-    data_vertex.color.b * data_vertex.brightness,
-    data_vertex.color.a
+  float4 colour_lighted = float4(
+    data_vertex.colour.r * data_vertex.brightness,
+    data_vertex.colour.g * data_vertex.brightness,
+    data_vertex.colour.b * data_vertex.brightness,
+    data_vertex.colour.a
   );
 
-  float4 color_fogged = fog_apply(
-    color_lighted,
+  float4 colour_fogged = fog_apply(
+    colour_lighted,
     data_vertex.distance
   );
 
-  return color_fogged;
+  return colour_fogged;
 }

--- a/examples/fog/sources/example_fog_scene.m
+++ b/examples/fog/sources/example_fog_scene.m
@@ -181,19 +181,19 @@ void example_fog_scene_initialize(
       ].buffer.contents
     );
 
-    data_object->color.x = (
+    data_object->colour.x = (
       (float) (index_renderable % 10) / 10.0f
     );
 
-    data_object->color.y = (
+    data_object->colour.y = (
       (float) ((index_renderable + 3) % 10) / 10.0f
     );
 
-    data_object->color.z = (
+    data_object->colour.z = (
       (float) ((index_renderable + 5) % 10) / 10.0f
     );
 
-    data_object->color.w = 1.0f;
+    data_object->colour.w = 1.0f;
   }
 
   metil_renderable_initialize_at_index(
@@ -228,19 +228,19 @@ void example_fog_scene_initialize(
     ].buffer.contents
   );
 
-  data_object->color.x = (
+  data_object->colour.x = (
     1.0f
   );
 
-  data_object->color.y = (
+  data_object->colour.y = (
     1.0f
   );
 
-  data_object->color.z = (
+  data_object->colour.z = (
     1.0f
   );
 
-  data_object->color.w = (
+  data_object->colour.w = (
     fog_thickness_maximum
   );
 

--- a/examples/model/metal/model.metal
+++ b/examples/model/metal/model.metal
@@ -6,7 +6,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex model_vertex(
@@ -56,7 +56,7 @@ struct data_vertex {
     position_vertex
   );
 
-  data_vertex.color = float4(
+  data_vertex.colour = float4(
     1.0f,
     1.0f,
     1.0f,
@@ -69,5 +69,5 @@ struct data_vertex {
 [[fragment]] float4 model_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/model/metal/model_item.metal
+++ b/examples/model/metal/model_item.metal
@@ -5,7 +5,7 @@
 struct data_vertex {
   float4 position [[position]];
   float point_size [[point_size]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex model_item_vertex(
@@ -38,11 +38,11 @@ struct data_vertex {
     10.0f
   );
 
-  data_vertex.color = float4(
-    metal::fmod(data_object->color.x + offset, 1.0f),
-    metal::fmod(data_object->color.y + offset, 1.0f),
-    metal::fmod(data_object->color.z + offset, 1.0f),
-    data_object->color.w
+  data_vertex.colour = float4(
+    metal::fmod(data_object->colour.x + offset, 1.0f),
+    metal::fmod(data_object->colour.y + offset, 1.0f),
+    metal::fmod(data_object->colour.z + offset, 1.0f),
+    data_object->colour.w
   );
 
   return data_vertex;
@@ -51,5 +51,5 @@ struct data_vertex {
 [[fragment]] float4 model_item_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/examples/model/sources/example_model_scene.m
+++ b/examples/model/sources/example_model_scene.m
@@ -378,19 +378,19 @@ void example_model_scene_initialize(
     ].buffer.contents
   );
 
-  metil_renderer_data_object->color.x = (
+  metil_renderer_data_object->colour.x = (
     0.0f
   );
 
-  metil_renderer_data_object->color.y = (
+  metil_renderer_data_object->colour.y = (
     1.0f / 3.0f
   );
 
-  metil_renderer_data_object->color.z = (
+  metil_renderer_data_object->colour.z = (
     2.0f / 3.0f
   );
 
-  metil_renderer_data_object->color.w = (
+  metil_renderer_data_object->colour.w = (
     1.0f
   );
   
@@ -637,18 +637,18 @@ void example_model_scene_poll(
     20.0f
   );
 
-  metil_renderer_data_object->color.x = (
-    metil_renderer_data_object->color.x +
+  metil_renderer_data_object->colour.x = (
+    metil_renderer_data_object->colour.x +
     shift
   );
 
-  metil_renderer_data_object->color.y = (
-    metil_renderer_data_object->color.y +
+  metil_renderer_data_object->colour.y = (
+    metil_renderer_data_object->colour.y +
     shift
   );
 
-  metil_renderer_data_object->color.z = (
-    metil_renderer_data_object->color.z +
+  metil_renderer_data_object->colour.z = (
+    metil_renderer_data_object->colour.z +
     shift
   );
 }

--- a/include/metil_configuration/metil_configuration_rendering_properties.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties.h
@@ -10,7 +10,7 @@ struct metil_configuration_rendering_properties {
   float brightness_text;
 
   unsigned char fps_display;
-  struct math_c_vector4_float color_fps_display;
+  struct math_c_vector4_float colour_fps_display;
 
   struct metil_configuration_rendering_properties_defaults defaults;
 };

--- a/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
@@ -8,17 +8,17 @@
 
 #define metil_configuration_rendering_properties_default_fps_display 1
 
-#define metil_configuration_rendering_properties_default_color_fps_display_x 1.0f
-#define metil_configuration_rendering_properties_default_color_fps_display_y 1.0f
-#define metil_configuration_rendering_properties_default_color_fps_display_z 1.0f
-#define metil_configuration_rendering_properties_default_color_fps_display_w 1.0f
+#define metil_configuration_rendering_properties_default_colour_fps_display_x 1.0f
+#define metil_configuration_rendering_properties_default_colour_fps_display_y 1.0f
+#define metil_configuration_rendering_properties_default_colour_fps_display_z 1.0f
+#define metil_configuration_rendering_properties_default_colour_fps_display_w 1.0f
 
 struct metil_configuration_rendering_properties_defaults {
   float brightness;
   float brightness_text;
 
   unsigned char fps_display;
-  struct math_c_vector4_float color_fps_display;
+  struct math_c_vector4_float colour_fps_display;
 
   unsigned char initialized;
 };

--- a/include/metil_rendering/metil_renderer_data_menu_item.h
+++ b/include/metil_rendering/metil_renderer_data_menu_item.h
@@ -10,7 +10,7 @@ struct metil_renderer_data_menu_item {
   struct math_c_vector3_float position;
   struct math_c_vector3_float size;
 
-  struct math_c_vector4_float color;
+  struct math_c_vector4_float colour;
 
   unsigned char selected;
 };

--- a/include/metil_rendering/metil_renderer_data_model_object.h
+++ b/include/metil_rendering/metil_renderer_data_model_object.h
@@ -13,7 +13,7 @@ struct metil_renderer_data_model_object {
   struct math_c_vector3_float position;
   struct math_c_vector3_float size;
 
-  struct math_c_vector4_float color;
+  struct math_c_vector4_float colour;
 
   unsigned int noise;
 };

--- a/include/metil_rendering/metil_renderer_data_object.h
+++ b/include/metil_rendering/metil_renderer_data_object.h
@@ -10,7 +10,7 @@ struct metil_renderer_data_object {
   struct math_c_vector3_float position;
   struct math_c_vector3_float size;
 
-  struct math_c_vector4_float color;
+  struct math_c_vector4_float colour;
 
   unsigned int noise;
 };

--- a/include/metil_rendering/metil_rendering_properties.h
+++ b/include/metil_rendering/metil_rendering_properties.h
@@ -25,10 +25,10 @@ struct metil_rendering_properties {
   float brightness;
   float brightness_text;
 
-  struct math_c_vector4_float color_clear;
+  struct math_c_vector4_float colour_clear;
 
   unsigned char fps_display;
-  struct math_c_vector4_float color_fps_display;
+  struct math_c_vector4_float colour_fps_display;
   float fps;
 
   unsigned char mode;

--- a/metal/basic_2d_shaders.metal
+++ b/metal/basic_2d_shaders.metal
@@ -4,7 +4,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex shader_2d_vertex(
@@ -34,11 +34,11 @@ struct data_vertex {
     ]
   );
 
-  data_vertex.color = float4(
-    data_object->color.x,
-    data_object->color.y,
-    data_object->color.z,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x,
+    data_object->colour.y,
+    data_object->colour.z,
+    data_object->colour.w
   );
 
   return data_vertex;
@@ -47,5 +47,5 @@ struct data_vertex {
 [[fragment]] float4 shader_2d_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/metal/basic_3d_shaders.metal
+++ b/metal/basic_3d_shaders.metal
@@ -4,7 +4,7 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex shader_3d_vertex(
@@ -32,11 +32,11 @@ struct data_vertex {
     vertices[id_vertex]
   );
 
-  data_vertex.color = float4(
-    data_object->color.x * data_frame->brightness,
-    data_object->color.y * data_frame->brightness,
-    data_object->color.z * data_frame->brightness,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x * data_frame->brightness,
+    data_object->colour.y * data_frame->brightness,
+    data_object->colour.z * data_frame->brightness,
+    data_object->colour.w
   );
 
   return data_vertex;
@@ -45,5 +45,5 @@ struct data_vertex {
 [[fragment]] float4 shader_3d_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.color;
+  return data_vertex.colour;
 }

--- a/metal/metil_fps_display.metal
+++ b/metal/metil_fps_display.metal
@@ -7,7 +7,7 @@
 struct data_vertex {
   float4 position [[position]];
   float2 position_texture;
-  float4 color;
+  float4 colour;
 };
 
 [[vertex]] struct data_vertex metil_fps_display_vertex(
@@ -47,11 +47,11 @@ struct data_vertex {
     vertices[id_vertex]
   );
 
-  data_vertex.color = float4(
-    data_object->color.x,
-    data_object->color.y,
-    data_object->color.z,
-    data_object->color.w
+  data_vertex.colour = float4(
+    data_object->colour.x,
+    data_object->colour.y,
+    data_object->colour.z,
+    data_object->colour.w
   );
 
   return data_vertex;
@@ -66,7 +66,7 @@ struct data_vertex {
     metal::mip_filter::linear
   );
 
-  float4 color_texture = float4(
+  float4 colour_texture = float4(
     texture.sample(
       sampler_texture,
       data_vertex.position_texture
@@ -74,9 +74,9 @@ struct data_vertex {
   );
 
   return float4(
-    color_texture[0] * data_vertex.color.r,
-    color_texture[1] * data_vertex.color.g,
-    color_texture[2] * data_vertex.color.b,
-    color_texture[3] * data_vertex.color.a
+    colour_texture[0] * data_vertex.colour.r,
+    colour_texture[1] * data_vertex.colour.g,
+    colour_texture[2] * data_vertex.colour.b,
+    colour_texture[3] * data_vertex.colour.a
   );
 }

--- a/readme.md
+++ b/readme.md
@@ -241,10 +241,10 @@ by default these are the configuration keys and values that `metil` parses for
 - `rendering_properties:brightness`: floating point value greater than or equal to `0.0f`
 - `rendering_properties:brightness_text`: floating point value greater than or equal to `0.0f`
 - `rendering_properties:fps_display`: integer value (`0`: disable fps display, `1`: enable fps display)
-- `rendering_properties:color_fps_display_r`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
-- `rendering_properties:color_fps_display_g`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
-- `rendering_properties:color_fps_display_b`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
-- `rendering_properties:color_fps_display_a`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
+- `rendering_properties:colour_fps_display_r`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
+- `rendering_properties:colour_fps_display_g`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
+- `rendering_properties:colour_fps_display_b`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
+- `rendering_properties:colour_fps_display_a`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
 
 #### key_value_pair_format
 
@@ -266,10 +266,10 @@ audio:volume->{0.01f};
 rendering_properties:brightness->{1.0f};
 rendering_properties:brightness_text->{1.0f};
 rendering_properties:fps_display->{1};
-rendering_properties:color_fps_display_r->{0.923f};
-rendering_properties:color_fps_display_g->{0.843f};
-rendering_properties:color_fps_display_b->{0.114f};
-rendering_properties:color_fps_display_a->{1.0f};
+rendering_properties:colour_fps_display_r->{0.923f};
+rendering_properties:colour_fps_display_g->{0.843f};
+rendering_properties:colour_fps_display_b->{0.114f};
+rendering_properties:colour_fps_display_a->{1.0f};
 ```
 
 ### input
@@ -298,7 +298,7 @@ this structure is used to interact more closely with the graphics device and the
 ### rendering_properties
 
 `metil->rendering_properties` is a more high level way to interact with the graphical pipeline  
-here you can set the rendering mode, change camera (`metil_camera`) settings, toggle fps display, set the brightness, or change the clear color!
+here you can set the rendering mode, change camera (`metil_camera`) settings, toggle fps display, set the brightness, or change the clear colour!
 
 ### scene_controller
 
@@ -743,7 +743,7 @@ metil_object_text_initialize(
 
 which renders text using the default font/size (`monospace 48px`) to a texture, allocates buffers, sets textures, sets vertices/indices as a square the size of the text
 
-[`metil_text`](sources/metil_text/metil_text.m) itself can be utilized for more specific renditions of text by passing specific render properties containing font information, color spaces, sizes, and then utilizing glyph encoding and text image rendering to create textures to be stored in metal buffers for gpu access
+[`metil_text`](sources/metil_text/metil_text.m) itself can be utilized for more specific renditions of text by passing specific render properties containing font information, colour spaces, sizes, and then utilizing glyph encoding and text image rendering to create textures to be stored in metal buffers for gpu access
 
 the size of text rendering does not correspond to it's displayed size of resolution but does however set the quality and scale of the text. The higher the initial `size` of text rendering the higher the quality of the font displayed, the actual size however is left up to the scaling factors of the renderer.
 

--- a/sources/metil_configuration/metil_configuration.m
+++ b/sources/metil_configuration/metil_configuration.m
@@ -189,10 +189,10 @@ unsigned char metil_configuration_load(
           "rendering_properties:brightness",
           "rendering_properties:brightness_text",
           "rendering_properties:fps_display",
-          "rendering_properties:color_fps_display_r",
-          "rendering_properties:color_fps_display_g",
-          "rendering_properties:color_fps_display_b",
-          "rendering_properties:color_fps_display_a"
+          "rendering_properties:colour_fps_display_r",
+          "rendering_properties:colour_fps_display_g",
+          "rendering_properties:colour_fps_display_b",
+          "rendering_properties:colour_fps_display_a"
         );
 
         if (
@@ -294,18 +294,18 @@ unsigned char metil_configuration_load(
             break;
           }
           case 4: {
-            float color_fps_display_r = metil_configuration_value_float_parse(
+            float colour_fps_display_r = metil_configuration_value_float_parse(
               metil_configuration,
               buffer_parameter,
               buffer_value
             );
 
             if (
-              color_fps_display_r >= 0.0f &&
-              color_fps_display_r <= 1.0f
+              colour_fps_display_r >= 0.0f &&
+              colour_fps_display_r <= 1.0f
             ) {
-              metil_configuration->rendering_properties.color_fps_display.x = (
-                color_fps_display_r
+              metil_configuration->rendering_properties.colour_fps_display.x = (
+                colour_fps_display_r
               );
             } else {
               status_configuration_load = 1;
@@ -314,18 +314,18 @@ unsigned char metil_configuration_load(
             break;
           }
           case 5: {
-            float color_fps_display_g = metil_configuration_value_float_parse(
+            float colour_fps_display_g = metil_configuration_value_float_parse(
               metil_configuration,
               buffer_parameter,
               buffer_value
             );
 
             if (
-              color_fps_display_g >= 0.0f &&
-              color_fps_display_g <= 1.0f
+              colour_fps_display_g >= 0.0f &&
+              colour_fps_display_g <= 1.0f
             ) {
-              metil_configuration->rendering_properties.color_fps_display.y = (
-                color_fps_display_g
+              metil_configuration->rendering_properties.colour_fps_display.y = (
+                colour_fps_display_g
               );
             } else {
               status_configuration_load = 1;
@@ -334,18 +334,18 @@ unsigned char metil_configuration_load(
             break;
           }
           case 6: {
-            float color_fps_display_b = metil_configuration_value_float_parse(
+            float colour_fps_display_b = metil_configuration_value_float_parse(
               metil_configuration,
               buffer_parameter,
               buffer_value
             );
 
             if (
-              color_fps_display_b >= 0.0f &&
-              color_fps_display_b <= 1.0f
+              colour_fps_display_b >= 0.0f &&
+              colour_fps_display_b <= 1.0f
             ) {
-              metil_configuration->rendering_properties.color_fps_display.z = (
-                color_fps_display_b
+              metil_configuration->rendering_properties.colour_fps_display.z = (
+                colour_fps_display_b
               );
             } else {
               status_configuration_load = 1;
@@ -354,18 +354,18 @@ unsigned char metil_configuration_load(
             break;
           }
           case 7: {
-            float color_fps_display_a = metil_configuration_value_float_parse(
+            float colour_fps_display_a = metil_configuration_value_float_parse(
               metil_configuration,
               buffer_parameter,
               buffer_value
             );
 
             if (
-              color_fps_display_a >= 0.0f &&
-              color_fps_display_a <= 1.0f
+              colour_fps_display_a >= 0.0f &&
+              colour_fps_display_a <= 1.0f
             ) {
-              metil_configuration->rendering_properties.color_fps_display.w = (
-                color_fps_display_a
+              metil_configuration->rendering_properties.colour_fps_display.w = (
+                colour_fps_display_a
               );
             } else {
               status_configuration_load = 1;

--- a/sources/metil_configuration/metil_configuration_rendering_properties.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties.c
@@ -23,19 +23,19 @@ void metil_configuration_rendering_properties_initialize(
     metil_configuration_rendering_properties->defaults.fps_display
   );
 
-  metil_configuration_rendering_properties->color_fps_display.x = (
-    metil_configuration_rendering_properties->defaults.color_fps_display.x
+  metil_configuration_rendering_properties->colour_fps_display.x = (
+    metil_configuration_rendering_properties->defaults.colour_fps_display.x
   );
 
-  metil_configuration_rendering_properties->color_fps_display.y = (
-    metil_configuration_rendering_properties->defaults.color_fps_display.y
+  metil_configuration_rendering_properties->colour_fps_display.y = (
+    metil_configuration_rendering_properties->defaults.colour_fps_display.y
   );
 
-  metil_configuration_rendering_properties->color_fps_display.z = (
-    metil_configuration_rendering_properties->defaults.color_fps_display.z
+  metil_configuration_rendering_properties->colour_fps_display.z = (
+    metil_configuration_rendering_properties->defaults.colour_fps_display.z
   );
 
-  metil_configuration_rendering_properties->color_fps_display.w = (
-    metil_configuration_rendering_properties->defaults.color_fps_display.w
+  metil_configuration_rendering_properties->colour_fps_display.w = (
+    metil_configuration_rendering_properties->defaults.colour_fps_display.w
   );
 }

--- a/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
@@ -15,20 +15,20 @@ void metil_configuration_rendering_properties_defaults_initialize(
     metil_configuration_rendering_properties_default_fps_display
   );
 
-  metil_configuration_rendering_properties_defaults->color_fps_display.x = (
-    metil_configuration_rendering_properties_default_color_fps_display_x
+  metil_configuration_rendering_properties_defaults->colour_fps_display.x = (
+    metil_configuration_rendering_properties_default_colour_fps_display_x
   );
 
-  metil_configuration_rendering_properties_defaults->color_fps_display.y = (
-    metil_configuration_rendering_properties_default_color_fps_display_y
+  metil_configuration_rendering_properties_defaults->colour_fps_display.y = (
+    metil_configuration_rendering_properties_default_colour_fps_display_y
   );
 
-  metil_configuration_rendering_properties_defaults->color_fps_display.z = (
-    metil_configuration_rendering_properties_default_color_fps_display_z
+  metil_configuration_rendering_properties_defaults->colour_fps_display.z = (
+    metil_configuration_rendering_properties_default_colour_fps_display_z
   );
 
-  metil_configuration_rendering_properties_defaults->color_fps_display.w = (
-    metil_configuration_rendering_properties_default_color_fps_display_w
+  metil_configuration_rendering_properties_defaults->colour_fps_display.w = (
+    metil_configuration_rendering_properties_default_colour_fps_display_w
   );
 
   metil_configuration_rendering_properties_defaults->initialized = (

--- a/sources/metil_object/metil_object_text.m
+++ b/sources/metil_object/metil_object_text.m
@@ -42,10 +42,10 @@ void metil_object_text_initialize(
     ].buffer.contents
   );
 
-  metil_renderer_data_object_text->color.x = 1.0f;
-  metil_renderer_data_object_text->color.y = 1.0f;
-  metil_renderer_data_object_text->color.z = 1.0f;
-  metil_renderer_data_object_text->color.w = 1.0f;
+  metil_renderer_data_object_text->colour.x = 1.0f;
+  metil_renderer_data_object_text->colour.y = 1.0f;
+  metil_renderer_data_object_text->colour.z = 1.0f;
+  metil_renderer_data_object_text->colour.w = 1.0f;
 
   metil_object_texture_add(
     metil_object_text,

--- a/sources/metil_rendering/metil_descriptors/metil_pipeline_render.m
+++ b/sources/metil_rendering/metil_descriptors/metil_pipeline_render.m
@@ -7,7 +7,7 @@ void metil_rendering_descriptors_pipeline_render_initialize(
   unsigned long count_samples,
   id<MTLFunction> function_fragment,
   id<MTLFunction> function_vertex,
-  MTLPixelFormat format_pixel_color_attachment,
+  MTLPixelFormat format_pixel_colour_attachment,
   MTLPixelFormat format_pixel_depth,
   MTLPixelFormat format_pixel_stencil
 ) {
@@ -16,7 +16,7 @@ void metil_rendering_descriptors_pipeline_render_initialize(
   descriptor_pipeline_render.fragmentFunction = function_fragment;
   descriptor_pipeline_render.vertexFunction = function_vertex;
 
-  descriptor_pipeline_render.colorAttachments[0].pixelFormat = format_pixel_color_attachment;
+  descriptor_pipeline_render.colorAttachments[0].pixelFormat = format_pixel_colour_attachment;
   descriptor_pipeline_render.colorAttachments[0].blendingEnabled = 1;
   descriptor_pipeline_render.colorAttachments[0].rgbBlendOperation = MTLBlendOperationAdd;
   descriptor_pipeline_render.colorAttachments[0].alphaBlendOperation = MTLBlendOperationAdd;

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -401,18 +401,18 @@
   descriptor_render_pass.colorAttachments[0].clearColor = (
     MTLClearColorMake(
       (
-        self->metil->rendering_properties.color_clear.x *
+        self->metil->rendering_properties.colour_clear.x *
         self->metil->rendering_properties.brightness
       ),
       (
-        self->metil->rendering_properties.color_clear.y *
+        self->metil->rendering_properties.colour_clear.y *
         self->metil->rendering_properties.brightness
       ),
       (
-        self->metil->rendering_properties.color_clear.z *
+        self->metil->rendering_properties.colour_clear.z *
         self->metil->rendering_properties.brightness
       ),
-      self->metil->rendering_properties.color_clear.w
+      self->metil->rendering_properties.colour_clear.w
     )
   );
 
@@ -1359,20 +1359,20 @@
       ].buffer.contents
     );
 
-    metil_renderer_data_object->color.x = (
-      self->metil->rendering_properties.color_fps_display.x
+    metil_renderer_data_object->colour.x = (
+      self->metil->rendering_properties.colour_fps_display.x
     );
 
-    metil_renderer_data_object->color.y = (
-      self->metil->rendering_properties.color_fps_display.y
+    metil_renderer_data_object->colour.y = (
+      self->metil->rendering_properties.colour_fps_display.y
     );
 
-    metil_renderer_data_object->color.z = (
-      self->metil->rendering_properties.color_fps_display.z
+    metil_renderer_data_object->colour.z = (
+      self->metil->rendering_properties.colour_fps_display.z
     );
 
-    metil_renderer_data_object->color.w = (
-      self->metil->rendering_properties.color_fps_display.w
+    metil_renderer_data_object->colour.w = (
+      self->metil->rendering_properties.colour_fps_display.w
     );
 
     [

--- a/sources/metil_rendering/metil_renderer_data_object.c
+++ b/sources/metil_rendering/metil_renderer_data_object.c
@@ -11,10 +11,10 @@ void metil_renderer_data_object_initialize(
   metil_renderer_data_object->size.y = 0.0f;
   metil_renderer_data_object->size.z = 0.0f;
 
-  metil_renderer_data_object->color.x = 1.0f;
-  metil_renderer_data_object->color.y = 1.0f;
-  metil_renderer_data_object->color.z = 1.0f;
-  metil_renderer_data_object->color.w = 1.0f;
+  metil_renderer_data_object->colour.x = 1.0f;
+  metil_renderer_data_object->colour.y = 1.0f;
+  metil_renderer_data_object->colour.z = 1.0f;
+  metil_renderer_data_object->colour.w = 1.0f;
 
   metil_renderer_data_object->noise = 0;
 }

--- a/sources/metil_rendering/metil_rendering_properties.c
+++ b/sources/metil_rendering/metil_rendering_properties.c
@@ -35,29 +35,29 @@ void metil_rendering_properties_initialize(
     metil_configuration_rendering_properties->brightness_text
   );
 
-  metil_rendering_properties->color_clear.x = 0.0f;
-  metil_rendering_properties->color_clear.y = 0.0f;
-  metil_rendering_properties->color_clear.z = 0.0f;
-  metil_rendering_properties->color_clear.w = 1.0f;
+  metil_rendering_properties->colour_clear.x = 0.0f;
+  metil_rendering_properties->colour_clear.y = 0.0f;
+  metil_rendering_properties->colour_clear.z = 0.0f;
+  metil_rendering_properties->colour_clear.w = 1.0f;
 
   metil_rendering_properties->fps_display = (
     metil_configuration_rendering_properties->fps_display
   );
 
-  metil_rendering_properties->color_fps_display.x = (
-    metil_configuration_rendering_properties->color_fps_display.x
+  metil_rendering_properties->colour_fps_display.x = (
+    metil_configuration_rendering_properties->colour_fps_display.x
   );
 
-  metil_rendering_properties->color_fps_display.y = (
-    metil_configuration_rendering_properties->color_fps_display.y
+  metil_rendering_properties->colour_fps_display.y = (
+    metil_configuration_rendering_properties->colour_fps_display.y
   );
 
-  metil_rendering_properties->color_fps_display.z = (
-    metil_configuration_rendering_properties->color_fps_display.z
+  metil_rendering_properties->colour_fps_display.z = (
+    metil_configuration_rendering_properties->colour_fps_display.z
   );
 
-  metil_rendering_properties->color_fps_display.w = (
-    metil_configuration_rendering_properties->color_fps_display.w
+  metil_rendering_properties->colour_fps_display.w = (
+    metil_configuration_rendering_properties->colour_fps_display.w
   );
 
   metil_rendering_properties->fps = 0.0f;

--- a/sources/metil_text/metil_text.m
+++ b/sources/metil_text/metil_text.m
@@ -223,16 +223,16 @@ struct metil_text_image* metil_text_render(
     text_image->data[index_pixel + 3] = value;
   }
 
-  CGColorSpaceRef color_space = CGColorSpaceCreateWithName(
+  CGColorSpaceRef colour_space = CGColorSpaceCreateWithName(
     kCGColorSpaceSRGB
   );
 
   if (
-    color_space == 0
+    colour_space == 0
   ) {
     metil_debug_log_error(
       metil_configuration->debug_log_level,
-      "couldn't create color space\n"
+      "couldn't create colour space\n"
     );
 
     clic3_memory_free_raw(
@@ -259,7 +259,7 @@ struct metil_text_image* metil_text_render(
       4 *
       text_image->size.x
     ),
-    color_space,
+    colour_space,
     0x0 | kCGImageAlphaNoneSkipFirst
   );
 
@@ -272,7 +272,7 @@ struct metil_text_image* metil_text_render(
     );
 
     CGColorSpaceRelease(
-      color_space
+      colour_space
     );
 
     clic3_memory_free_raw(
@@ -303,7 +303,7 @@ struct metil_text_image* metil_text_render(
   );
 
   CGColorSpaceRelease(
-    color_space
+    colour_space
   );
 
   clic3_memory_free_raw(


### PR DESCRIPTION
- `color`->`colour`
- - use the correct spelling of colour