### PR TITLE
[enh] `metil_configuration`:continue_with_errors_in_configuration_file

### DIFF
--- a/sources/metil_configuration/metil_configuration.m
+++ b/sources/metil_configuration/metil_configuration.m
@@ -55,7 +55,10 @@ unsigned char metil_configuration_load(
       "failed_to_[open|create]->{configuration}"
     );
 
-    status_configuration_load = 1;
+    status_configuration_load = (
+      status_configuration_load +
+      1
+    );
 
     return status_configuration_load;
   }
@@ -69,8 +72,9 @@ unsigned char metil_configuration_load(
   );
 
   while (
-    feof(file_configuration) == 0 &&
-    status_configuration_load == 0
+    feof(
+      file_configuration
+    ) == 0
   ) {
     char c = (
       getc(
@@ -92,9 +96,14 @@ unsigned char metil_configuration_load(
         "configuration_file_contains_too_long_of_a_line"
       );
 
-      status_configuration_load = 1;
+      status_configuration_load = (
+        status_configuration_load +
+        1
+      );
 
-      break;
+      length_buffer = 0;
+
+      continue;
     }
 
     if (
@@ -134,7 +143,10 @@ unsigned char metil_configuration_load(
             "invalid_configuration_file"
           );
 
-          status_configuration_load = 1;
+          status_configuration_load = (
+            status_configuration_load +
+            1
+          );
 
           break;
         }
@@ -195,42 +207,44 @@ unsigned char metil_configuration_load(
           "rendering_properties:colour_fps_display_a"
         );
 
-        if (
-          index_parameter == -1
+        switch (
+          index_parameter
         ) {
-          char* message_debug_log_error_prefix = (
-            clic3_char_arrays_concatenate(
-              "unknown_configuration_parameter->{",
-              buffer_parameter
-            )
-          );
+          case -1: {
+            char* message_debug_log_error_prefix = (
+              clic3_char_arrays_concatenate(
+                "unknown_configuration_parameter->{",
+                buffer_parameter
+              )
+            );
 
-          char* message_debug_log_error = (
-            clic3_char_arrays_concatenate(
-              message_debug_log_error,
-              "};\n"
-            )
-          );
+            char* message_debug_log_error = (
+              clic3_char_arrays_concatenate(
+                message_debug_log_error_prefix,
+                "};\n"
+              )
+            );
 
-          metil_debug_log_error(
-            metil_configuration->debug_log_level,
-            message_debug_log_error
-          );
+            metil_debug_log_error(
+              metil_configuration->debug_log_level,
+              message_debug_log_error
+            );
 
-          clic3_memory_free_raw(
-            message_debug_log_error_prefix
-          );
+            clic3_memory_free_raw(
+              message_debug_log_error_prefix
+            );
 
-          clic3_memory_free_raw(
-            message_debug_log_error
-          );
+            clic3_memory_free_raw(
+              message_debug_log_error
+            );
 
-          status_configuration_load = 1;
+            status_configuration_load = (
+              status_configuration_load +
+              1
+            );
 
-          break;
-        }
-
-        switch (index_parameter) {
+            break;
+          }
           case 0: {
             float audio_volume = metil_configuration_value_float_parse(
               metil_configuration,
@@ -238,10 +252,15 @@ unsigned char metil_configuration_load(
               buffer_value
             );
 
-            if (audio_volume >= 0.0f) {
+            if (
+              audio_volume >= 0.0f
+            ) {
               metil_configuration->audio.volume = audio_volume;
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
@@ -256,7 +275,10 @@ unsigned char metil_configuration_load(
             if (rendering_brightness >= 0.0f) {
               metil_configuration->rendering_properties.brightness = rendering_brightness;
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
@@ -271,7 +293,10 @@ unsigned char metil_configuration_load(
             if (rendering_brightness_text >= 0.0f) {
               metil_configuration->rendering_properties.brightness_text = rendering_brightness_text;
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
@@ -288,7 +313,10 @@ unsigned char metil_configuration_load(
             ) {
               metil_configuration->rendering_properties.fps_display = fps_display;
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
@@ -308,7 +336,10 @@ unsigned char metil_configuration_load(
                 colour_fps_display_r
               );
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
             
             break;
@@ -328,7 +359,10 @@ unsigned char metil_configuration_load(
                 colour_fps_display_g
               );
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
@@ -348,7 +382,10 @@ unsigned char metil_configuration_load(
                 colour_fps_display_b
               );
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
@@ -368,18 +405,21 @@ unsigned char metil_configuration_load(
                 colour_fps_display_a
               );
             } else {
-              status_configuration_load = 1;
+              status_configuration_load = (
+                status_configuration_load +
+                1
+              );
             }
 
             break;
           }
         }
 
-        clic3_memory_free(
+        clic3_memory_free_raw(
           buffer_parameter
         );
 
-        clic3_memory_free(
+        clic3_memory_free_raw(
           buffer_value
         );
                       
@@ -387,7 +427,8 @@ unsigned char metil_configuration_load(
       }
     } else {
       length_buffer = (
-        length_buffer + 1
+        length_buffer +
+        1
       );
 
       clic3_memory_reallocate_raw(
@@ -396,7 +437,8 @@ unsigned char metil_configuration_load(
       );
 
       buffer[
-        length_buffer - 1
+        length_buffer -
+        1
       ] = (
         c
       );

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -6,6 +6,7 @@
 #include <metil_audio/metil_audio.h>
 #include <metil_configuration/metil_configuration.h>
 #include <metil_configuration/metil_configuration_values_set.h>
+#include <metil_debug/metil_debug_log.h>
 #include <metil_input/metil_input.h>
 #include <metil_library.h>
 #include <metil_paths/metil_paths.h>
@@ -17,6 +18,9 @@
 #include <metil_text/metil_text.h>
 #include <metil_text/metil_text_defaults.h>
 #include <metil_utilities/metil_time.h>
+
+#include <clic3_char_arrays.h>
+#include <clic3_memory.h>
 
 #include <interrupt_handler.h>
 
@@ -90,17 +94,42 @@ int metil_initialize_with_data(
   if (
     status_configuration_load != 0
   ) {
-    metil_paths_destroy(
-      &metil.paths
+    char* char_array_status_configuration_load = (
+      clic3_char_array_from_unsigned_long_int(
+        status_configuration_load
+      )
     );
-    #if target_os_ios
-    exit(
-      status_configuration_load
+
+    char* log_debug_prefix = (
+      clic3_char_arrays_concatenate(
+        "configuration_loaded_with_errors->[",
+        char_array_status_configuration_load
+      )
     );
-    #else
-    [[NSApplication sharedApplication] terminate: 0];
-    #endif
-    return status_configuration_load;
+
+    char* log_debug = (
+      clic3_char_arrays_concatenate(
+        log_debug_prefix,
+        "];\n"
+      )
+    );
+
+    metil_debug_log_error(
+      metil.configuration.debug_log_level,
+      log_debug
+    );
+
+    clic3_memory_free_raw(
+      char_array_status_configuration_load
+    );
+
+    clic3_memory_free_raw(
+      log_debug_prefix
+    );
+
+    clic3_memory_free_raw(
+      log_debug
+    );
   }
   #endif
 


### PR DESCRIPTION
- `metil_configuration`
- - continues loading/parsing even when there are errors
- - prevents invalid configuration files from preventing launches