### PR TITLE
[enh] `metil_renderer_data_frame`:add->{`time_elapsed`};

### DIFF
--- a/include/metil_rendering/metil_renderer_data_frame.h
+++ b/include/metil_rendering/metil_renderer_data_frame.h
@@ -7,6 +7,7 @@ struct metil_renderer_data_frame {
   unsigned int frame;
 
   unsigned long int time;
+  unsigned long int time_elapsed;
   unsigned long int time_delta;
 
   struct math_c_vector3_float rotation_camera;

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -895,6 +895,7 @@
   data_frame->frame = poll_frame;
 
   data_frame->time = metil_scene->time;
+  data_frame->time_elapsed = metil_scene->time_elapsed;
   data_frame->time_delta = metil_scene->time_delta;
 
   data_frame->rotation_camera.x = metil_player->rotation.x;


### PR DESCRIPTION
- `metil_renderer_data_frame`:
- - add->{`time_elapsed`};