### PR TITLE
[bug|enh] `metil_time`::additional defines

### DIFF
--- a/include/metil_utilities/metil_time.h
+++ b/include/metil_utilities/metil_time.h
@@ -1,9 +1,17 @@
 #ifndef __metil_utilities_metil_time_h
 #define __metil_utilities_metil_time_h
 
+#define metil_time_microseconds_to_milliseconds(x) ((x) / 1000)
+#define metil_time_microseconds_to_seconds(x) ((x) / 1000000000)
+#define metil_time_microseconds_to_minutes(x) ((x) / 60000000000)
+
+#define metil_time_milliseconds_to_microseconds(x) ((x) * 1000)
+#define metil_time_milliseconds_to_seconds(x) ((x) / 1000)
+#define metil_time_milliseconds_to_minutes(x) ((x) / 60000)
+
 #define metil_time_seconds_to_microseconds(x) ((x) * 1000000000)
 #define metil_time_seconds_to_milliseconds(x) ((x) * 1000)
-#define metil_time_microseconds_to_milliseconds(x) ((x) / 1000)
+#define metil_time_seconds_to_minutes(x) ((x) / 60)
 
 unsigned long int metil_time_milliseconds_get();
 

--- a/include/metil_utilities/metil_time.h
+++ b/include/metil_utilities/metil_time.h
@@ -13,6 +13,10 @@
 #define metil_time_seconds_to_milliseconds(x) ((x) * 1000)
 #define metil_time_seconds_to_minutes(x) ((x) / 60)
 
+#define metil_time_minute_to_microseconds(x) ((x) * 60000000)
+#define metil_time_minute_to_milliseconds(x) ((x) * 60000)
+#define metil_time_minute_to_seconds(x) ((x) * 60)
+
 unsigned long int metil_time_milliseconds_get();
 
 #endif

--- a/include/metil_utilities/metil_time.h
+++ b/include/metil_utilities/metil_time.h
@@ -2,14 +2,14 @@
 #define __metil_utilities_metil_time_h
 
 #define metil_time_microseconds_to_milliseconds(x) ((x) / 1000)
-#define metil_time_microseconds_to_seconds(x) ((x) / 1000000000)
-#define metil_time_microseconds_to_minutes(x) ((x) / 60000000000)
+#define metil_time_microseconds_to_seconds(x) ((x) / 1000000)
+#define metil_time_microseconds_to_minutes(x) ((x) / 60000000)
 
 #define metil_time_milliseconds_to_microseconds(x) ((x) * 1000)
 #define metil_time_milliseconds_to_seconds(x) ((x) / 1000)
 #define metil_time_milliseconds_to_minutes(x) ((x) / 60000)
 
-#define metil_time_seconds_to_microseconds(x) ((x) * 1000000000)
+#define metil_time_seconds_to_microseconds(x) ((x) * 1000000)
 #define metil_time_seconds_to_milliseconds(x) ((x) * 1000)
 #define metil_time_seconds_to_minutes(x) ((x) / 60)
 


### PR DESCRIPTION
- `metil_time`:
- - fix microsecond conversions
- - add conversions to minutes