### PR TITLE
[enh] `metil_animation`

### DIFF
--- a/examples/animation/include/example_animation.h
+++ b/examples/animation/include/example_animation.h
@@ -1,0 +1,16 @@
+#ifndef __example_animation_h
+#define __example_animation_h
+
+#include <metil.h>
+
+int main(
+  int,
+  const char* _Nonnull * _Nonnull
+);
+
+void example_animation_renderer_on_initialize(
+  struct metil* _Nonnull,
+  void* _Nullable
+);
+
+#endif

--- a/examples/animation/include/example_animation_scene.h
+++ b/examples/animation/include/example_animation_scene.h
@@ -1,0 +1,17 @@
+#ifndef __example_animation_scene_h
+#define __example_animation_scene_h
+
+#include <metil.h>
+#include <metil_scenes/metil_scene.h>
+
+void example_animation_scene_initialize(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull
+);
+
+void example_animation_scene_poll(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull
+);
+
+#endif

--- a/examples/animation/makefile
+++ b/examples/animation/makefile
@@ -1,0 +1,226 @@
+name=example_animation
+
+directory_objects_base=objects
+directory_output_base=output
+
+directory_air=air
+directory_metal=metal
+directory_objects=${directory_objects_base}/release
+
+ifeq (${debug}, 1)
+	name:=${name}_debug
+	directory_objects=${directory_objects_base}/debug
+	directory_output=${directory_output_base}/debug
+else
+	directory_output=${directory_output_base}/release
+endif
+
+version_target_cer0=0
+version_target_clic3=0
+version_target_interrupt_handler=0
+version_target_math_c=0
+version_target_metil=1
+
+directory_include=include
+directory_objects_c=${directory_objects}/c
+directory_objects_objc=${directory_objects}/objc
+directory_sources=sources
+
+directory_cer0=../../../cer0
+directory_cer0_include=${directory_cer0}/include
+
+directory_clic3=../../../clic3
+directory_clic3_include=${directory_clic3}/include
+
+directory_interrupt_handler=../../../interrupt_handler
+
+directory_math_c=../../../math_c
+directory_math_c_include=${directory_math_c}/include
+
+directory_metil=../..
+directory_metil_include=${directory_metil}/include
+directory_metil_library=${directory_metil}/library/macos
+directory_metil_plist=${directory_metil}/plist
+
+ifeq (${debug}, 1)
+directory_cer0_library=${directory_cer0}/library/macos/debug
+directory_clic3_library=${directory_clic3}/library/macos/debug
+directory_interrupt_handler_library=${directory_interrupt_handler}/library/macos/debug
+directory_math_c_library=${directory_math_c}/library/macos/debug
+directory_metil_library:=${directory_metil_library}/debug
+
+file_cer0_library=${directory_cer0_library}/cer0_debug.${version_target_cer0}.dylib
+file_clic3_library=${directory_clic3_library}/clic3_debug.${version_target_clic3}.dylib
+file_interrupt_handler_library=${directory_interrupt_handler_library}/interrupt_handler_debug.${version_target_interrupt_handler}.dylib
+file_math_c_library=${directory_math_c_library}/math_c_debug.${version_target_math_c}.dylib
+file_metil_library=${directory_metil_library}/metil_debug.${version_target_metil}.dylib
+else
+directory_cer0_library=${directory_cer0}/library/macos/release
+directory_clic3_library=${directory_clic3}/library/macos/release
+directory_interrupt_handler_library=${directory_interrupt_handler}/library/macos/release
+directory_math_c_library=${directory_math_c}/library/macos/release
+directory_metil_library:=${directory_metil_library}/release
+
+file_cer0_library=${directory_cer0_library}/cer0.${version_target_cer0}.dylib
+file_clic3_library=${directory_clic3_library}/clic3.${version_target_clic3}.dylib
+file_interrupt_handler_library=${directory_interrupt_handler_library}/interrupt_handler.${version_target_interrupt_handler}.dylib
+file_math_c_library=${directory_math_c_library}/math_c.${version_target_math_c}.dylib
+file_metil_library=${directory_metil_library}/metil.${version_target_metil}.dylib
+endif
+
+directory_app=${directory_output}/${name}.app
+directory_app_contents=${directory_app}/Contents
+directory_app_contents_macos=${directory_app_contents}/MacOS
+directory_app_contents_resources=${directory_app_contents}/Resources
+
+ifndef target_device_version
+target_device_version=26.1
+endif
+
+ifndef target_metal_version
+target_metal_version=${target_device_version}
+endif
+
+ifndef target_metal_standard
+target_metal_standard=metal4.0
+endif
+
+
+target_platform=arm64-apple-macos${target_device_version}
+target_platform_metal=air64-apple-macos${target_metal_version}
+
+directory_sdk=${shell xcrun --sdk macosx${target_device_version} --show-sdk-path}
+
+file_metalar_metil_fps_display=${directory_metil_library}/metil_fps_display.metalar
+file_metalar_metil_wireframe=${directory_metil_library}/metil_wireframe.metalar
+
+file_metil_metallib=${directory_metil_library}/metil.metallib
+file_metil_storyboard=${directory_metil_library}/metil.storyboardc
+
+file_info_plist=${directory_metil_plist}/Info.plist
+file_output=${directory_app_contents_macos}/${name}
+file_output_info_plist=${directory_app_contents}/Info.plist
+file_output_metal=${directory_app_contents_resources}/default.metallib
+file_output_storyboard=${directory_app_contents_resources}/metil.storyboardc
+
+files_libraries=${file_cer0_library} ${file_clic3_library} ${file_interrupt_handler_library} ${file_metil_library} ${file_math_c_library}
+
+files_metal=${wildcard ${directory_metal}/*.metal}
+files_air=${patsubst ${directory_metal}/%.metal,${directory_air}/%.air,${files_metal}}
+
+files_sources_c=${shell find ${directory_sources} -name "*.c"}
+files_sources_objc=${shell find ${directory_sources} -name "*.m"}
+
+files_objects_c=${patsubst ${directory_sources}/%.c,${directory_objects_c}/%.o,${files_sources_c}}
+files_objects_objc=${patsubst ${directory_sources}/%.m,${directory_objects_objc}/%.o,${files_sources_objc}}
+
+frameworks=Metal MetalKit GameController CoreAudio CoreGraphics CoreText
+
+cc=clang
+c_flags_includes=-I${directory_include} -I${directory_cer0_include} -I${directory_clic3_include} -I${directory_math_c_include} -I${directory_metil_include}
+c_flags_platform=-target ${target_platform} -isysroot ${directory_sdk}
+
+c_flags_objc_debug=-O0 -g -v
+c_flags_debug=${c_flags_objc_debug} -da -Q
+
+c_flags_c=${c_flags_platform} ${c_flags_includes}
+c_flags_objc=${c_flags_platform} ${c_flags_includes} -x objective-c -fmodules -fconstant-cfstrings -DTARGET_MACOS
+c_flags_frameworks=${addprefix -framework ,${frameworks}}
+c_flags_output=${c_flags_platform} ${c_flags_frameworks}
+
+ifeq (${debug}, 1)
+	c_flags_c:=${c_flags_c} ${c_flags_debug}
+	c_flags_objc:=${c_flags_objc} ${c_flags_objc_debug}
+	c_flags_output:=${c_flags_output} ${c_flags_objc_debug}
+else
+	c_flags_c:=${c_flags_c} -O3
+	c_flags_objc:=${c_flags_objc} -O3
+	c_flags_output:=${c_flags_output} -O3
+endif
+
+strip=strip
+strip_flags=-x
+
+metal=xcrun -sdk macosx metal
+metal_ar=xcrun -sdk macosx metal-ar
+metallib=xcrun -sdk macosx metallib
+metal_flags_common=-target ${target_platform_metal} -std=${target_metal_standard}
+
+metal_flags=${metal_flags_common} -I${directory_include} -I${directory_math_c_include} -I${directory_metil_include} -isysroot ${directory_sdk}
+
+ifneq (${disable_metal_fast_options}, 1)
+	metal_flags:=${metal_flags} -fmetal-math-mode\=fast -fmetal-math-fp32-functions\=fast
+endif
+
+metal_flags_output=
+
+all: ${name}
+
+run:
+	cd ${dir ${file_output}} && ./${shell basename ${file_output}}
+
+${name}: ${file_output}
+
+${file_output}: ${files_objects_c} ${files_objects_objc} ${file_output_info_plist} ${file_output_metal} ${file_output_storyboard}
+	mkdir -p ${directory_app_contents_macos}
+	${cc} ${c_flags_output} ${files_objects_c} ${files_objects_objc} ${files_libraries} -o ${file_output}
+ifneq (${debug}, 1)
+	${strip} ${strip_flags} ${file_output}
+endif
+ifneq (${release}, 1)
+ifeq (${debug}, 1)
+	if [[ ! -f ${directory_app_contents_macos}/cer0_debug.${version_target_cer0}.dylib ]]; then ln -s ../../../../../${file_cer0_library} ${directory_app_contents_macos}/cer0_debug.${version_target_cer0}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/clic3_debug.${version_target_clic3}.dylib ]]; then ln -s ../../../../../${file_clic3_library} ${directory_app_contents_macos}/clic3_debug.${version_target_clic3}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/interrupt_handler_debug.${version_target_interrupt_handler}.dylib ]]; then ln -s ../../../../../${file_interrupt_handler_library} ${directory_app_contents_macos}/interrupt_handler_debug.${version_target_interrupt_handler}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/math_c_debug.${version_target_math_c}.dylib ]]; then ln -s ../../../../../${file_math_c_library} ${directory_app_contents_macos}/math_c_debug.${version_target_math_c}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/metil_debug.${version_target_metil}.dylib ]]; then ln -s ../../../../../${file_metil_library} ${directory_app_contents_macos}/metil_debug.${version_target_metil}.dylib; fi
+else
+	if [[ ! -f ${directory_app_contents_macos}/cer0.${version_target_cer0}.dylib ]]; then ln -s ../../../../../${file_cer0_library} ${directory_app_contents_macos}/cer0.${version_target_cer0}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/clic3.${version_target_clic3}.dylib ]]; then ln -s ../../../../../${file_clic3_library} ${directory_app_contents_macos}/clic3.${version_target_clic3}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/interrupt_handler.${version_target_interrupt_handler}.dylib ]]; then ln -s ../../../../../${file_interrupt_handler_library} ${directory_app_contents_macos}/interrupt_handler.${version_target_interrupt_handler}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/math_c.${version_target_math_c}.dylib ]]; then ln -s ../../../../../${file_math_c_library} ${directory_app_contents_macos}/math_c.${version_target_math_c}.dylib; fi
+	if [[ ! -f ${directory_app_contents_macos}/metil.${version_target_metil}.dylib ]]; then ln -s ../../../../../${file_metil_library} ${directory_app_contents_macos}/metil.${version_target_metil}.dylib; fi
+endif
+endif
+
+${file_output_metal}: ${files_air}
+	mkdir -p "${dir ${file_output_metal}}"
+	${metallib} ${metal_flags_output} ${files_air} ${file_metalar_metil_wireframe} ${file_metalar_metil_fps_display} -o ${file_output_metal}
+
+${directory_air}/%.air: ${directory_metal}/%.metal
+	mkdir -p "${dir $@}"
+	${metal} ${metal_flags} -c $< -o $@
+
+${directory_objects_c}/%.o: ${directory_sources}/%.c
+	mkdir -p "${dir $@}"
+	${cc} ${c_flags_c} -c $< -o $@
+
+${directory_objects_objc}/%.o: ${directory_sources}/%.m
+	mkdir -p "${dir $@}"
+	${cc} ${c_flags_objc} -c $< -o $@
+
+${file_output_storyboard}: ${file_metil_storyboard}
+	mkdir -p ${directory_app_contents_resources}
+	cp -r ${file_metil_storyboard} ${file_output_storyboard}
+
+${file_output_info_plist}: ${file_info_plist}
+	mkdir -p ${directory_app_contents}
+	cp ${file_info_plist} ${file_output_info_plist}
+
+clean_all: clean
+
+clean: clean_metal clean_objects clean_output
+
+clean_metal: clean_air clean_metalib
+
+clean_air:
+	-rm -r "${directory_air}" 2> /dev/null
+
+clean_metalib:
+	-rm "${file_output_metal}" 2> /dev/null
+
+clean_objects:
+	-rm -r ${directory_objects_base}
+
+clean_output:
+	-rm -r ${directory_output_base}

--- a/examples/animation/metal/example_animation.metal
+++ b/examples/animation/metal/example_animation.metal
@@ -1,0 +1,85 @@
+#include <metil_metal/basic_3d_shaders.h>
+
+#include <metil_metal/metil_metal_data_vertex.h>
+
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+
+[[vertex]] struct data_vertex_basic_coloured shader_example_animation_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex_basic_coloured data_vertex_basic_coloured;
+
+  data_vertex_basic_coloured.position = (
+    data_object->view_model_matrix_projection *
+    vertices[
+      id_vertex
+    ]
+  );
+
+
+  data_vertex_basic_coloured.colour = (
+    float4(
+      (
+        (
+          (
+            id_vertex %
+            3
+          ) == 0
+          ? 1.0f
+          : 0.0f
+        ) *
+        data_frame->brightness
+      ),
+      (
+        (
+          (
+            id_vertex %
+            3
+          ) == 1
+          ? 1.0f
+          : 0.0f
+        ) *
+        data_frame->brightness
+      ),
+      (
+        (
+          (
+            id_vertex %
+            3
+          ) == 2
+          ? 1.0f
+          : 0.0f
+        ) *
+        data_frame->brightness
+      ),
+      data_object->colour.w
+    )
+  );
+
+  return data_vertex_basic_coloured;
+}
+
+[[fragment]] float4 shader_example_animation_fragment(
+  struct data_vertex_basic_coloured data_vertex_basic_coloured [[stage_in]]
+) {
+  return (
+    data_vertex_basic_coloured.colour
+  );
+}

--- a/examples/animation/sources/example_animation.m
+++ b/examples/animation/sources/example_animation.m
@@ -1,0 +1,37 @@
+#include <example_animation.h>
+
+#include <example_animation_scene.h>
+
+#include <metil.h>
+#include <metil_initialize.h>
+#include <metil_library.h>
+#include <metil_scenes/metil_scene_controller.h>
+
+int main(
+  int length_parameters,
+  const char** parameters
+) {
+  return metil_initialize(
+    length_parameters,
+    parameters,
+    "example_animation",
+    example_animation_renderer_on_initialize
+  );
+}
+
+void example_animation_renderer_on_initialize(
+  struct metil* metil,
+  void* data
+) {
+  metil_library_initialize(
+    &metil->library,
+    metil->renderer_interface.metal_device,
+    @"shader_example_animation_fragment",
+    @"shader_example_animation_vertex"
+  );
+
+  example_animation_scene_initialize(
+    metil,
+    &((struct metil_scene_controller*) metil->scene_controller)->scene
+  );
+}

--- a/examples/animation/sources/example_animation_scene.m
+++ b/examples/animation/sources/example_animation_scene.m
@@ -1,0 +1,403 @@
+#include <example_animation_scene.h>
+
+#include <metil.h>
+
+/* 2d animation */
+#include <metil_mesh/metil_mesh_2d/metil_mesh_circle.h>
+#include <metil_mesh/metil_mesh_2d/metil_mesh_rectangle.h>
+#include <metil_mesh/metil_mesh_2d/metil_mesh_square.h>
+#include <metil_mesh/metil_mesh_2d/metil_mesh_triangle.h>
+
+/* 3d animation */
+#include <metil_mesh/metil_mesh_ball.h>
+#include <metil_mesh/metil_mesh_box.h>
+#include <metil_mesh/metil_mesh_dollop.h>
+#include <metil_mesh/metil_mesh_gem.h>
+#include <metil_mesh/metil_mesh_mushroom.h>
+#include <metil_mesh/metil_mesh_ring.h>
+#include <metil_mesh/metil_mesh_shuttle.h>
+#include <metil_mesh/metil_mesh_sphere.h>
+#include <metil_mesh/metil_mesh_tube.h>
+
+#include <metil_animation/metil_animation.h>
+#include <metil_object.h>
+#include <metil_player/metil_player.h>
+#include <metil_rendering/metil_renderable.h>
+#include <metil_rendering/metil_renderable_type.h>
+#include <metil_rendering/metil_renderer_data_object.h>
+#include <metil_scenes/metil_scene.h>
+
+#include <clic3_memory.h>
+
+#include <math_c_pi.h>
+#include <math_c_vector.h>
+
+struct metil_animation an[13];
+
+void s(
+  struct metil_animation* ani,
+  enum metil_renderable_type type,
+  void* renderable
+) {
+  struct metil_object* o = renderable;
+
+  if (ani->direction) {
+    o->position.y = (
+      o->position.y -
+      5.0
+    );
+  } else {
+    o->position.y = (
+      
+      o->position.y + 5.0
+    );
+  }
+}
+
+void e(
+  struct metil_animation* ani,
+  enum metil_renderable_type type,
+  void* renderable
+) {
+  struct metil_object* o = renderable;
+
+  // o->position.y = (
+  //   o->position.y + 5.0f
+  // );
+}
+
+void a(
+  struct metil_animation* ani,
+  enum metil_renderable_type type,
+  void* renderable,
+  float percentage
+) {
+  struct metil_object* o = renderable;
+
+  o->rotation.x = (
+    percentage * 4.0f
+  );
+}
+
+void example_animation_scene_initialize(
+  struct metil* metil,
+  struct metil_scene* metil_scene
+) {
+  metil_scene_initialize_with_renderables(
+    metil,
+    metil_scene,
+    13
+  );
+
+  for (
+    unsigned int i = 0 ; i < 13; 
+    ++i
+  ) {
+  metil_animation_initialize(
+    &an[i]
+  );
+
+  an[i].state = metil_animation_state_starting;
+
+  if (i % 2 == 0) {
+    an[i].direction = (!an[i].direction);
+  }
+
+  switch (i % 3) {
+    case 0:
+     an[i].loops = metil_animation_loop_none;
+     break;
+     case 1:
+     an[i].loops =metil_animation_loop_loops;
+     break;
+     case 2:
+     an[i].loops =metil_animation_loop_loops_mirrored;
+  }
+
+  an[i].length = (
+    1000 +
+    i * 100
+  );
+
+  an[i].poll = a;
+  an[i].start = s;
+  an[i].end = e;
+  }
+
+
+  metil_scene->poll = (
+    example_animation_scene_poll
+  );
+
+  float width = (
+    metil_scene->length_renderables *
+    20.0f
+  );
+
+  for (
+    unsigned int index_renderable = 0;
+    index_renderable < metil_scene->length_renderables;
+    ++index_renderable
+  ) {
+    metil_renderable_initialize_at_index(
+      metil_scene->renderables,
+      index_renderable,
+      metil_renderable_type_object
+    );
+
+    struct metil_object* metil_object = (
+      metil_scene->renderables[
+        index_renderable
+      ].renderable
+    );
+
+    struct metil_mesh* metil_mesh = (
+      &metil_object->mesh
+    );
+
+    switch (
+      index_renderable %
+      13
+    ) {
+      case 0: {
+        metil_mesh_circle_initialize(
+          metil_mesh,
+          10.0f,
+          100
+        );
+
+        break;
+      }
+      case 1: {
+        metil_mesh_rectangle_initialize(
+          metil_mesh,
+          (struct math_c_vector2_float) {
+            .x = 10.0f,
+            .y = 5.0f
+          }
+        );
+
+        break;
+      }
+      case 2: {
+        metil_mesh_square_initialize(
+          metil_mesh,
+          10.0f
+        );
+
+        break;
+      }
+      case 3: {
+        metil_mesh_triangle_initialize(
+          metil_mesh,
+          (struct math_c_vector2_float) {
+            .x = 10.0f,
+            .y = 10.0f
+          }
+        );
+
+        break;
+      }
+      case 4: {
+        metil_mesh_ball_initialize(
+          metil_mesh,
+          10,
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 100,
+            .y = 100
+          }
+        );
+
+        break;
+      }
+      case 5: {
+        metil_mesh_box_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          }
+        );
+
+        break;
+      }
+      case 6: {
+        metil_mesh_dollop_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          },
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 100,
+            .y = 100
+          }
+        );
+
+        break;
+      }
+      case 7: {
+        metil_mesh_gem_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          },
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 100,
+            .y = 100
+          }
+        );
+
+        break;
+      }
+      case 8: {
+        metil_mesh_mushroom_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          },
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 110,
+            .y = 110
+          }
+        );
+
+        break;
+      }
+      case 9: {
+        metil_mesh_ring_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 1.0f,
+            .z = 10.0f
+          },
+          (struct math_c_vector3_float) {
+            .x = 8.0f,
+            .y = 1.0f,
+            .z = 8.0f
+          },
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 100,
+            .y = 100
+          }
+        );
+
+        break;
+      }
+      case 10: {
+        metil_mesh_shuttle_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          },
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 7,
+            .y = 7
+          }
+        );
+
+        break;
+      }
+      case 11: {
+        metil_mesh_sphere_initialize(
+          metil_mesh,
+          10,
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 100,
+            .y = 100
+          }
+        );
+
+        break;
+      }
+      case 12: {
+        metil_mesh_tube_initialize(
+          metil_mesh,
+          (struct math_c_vector3_float) {
+            .x = 10.0f,
+            .y = 10.0f,
+            .z = 10.0f
+          },
+          (struct math_c_vector2_unsigned_short_int) {
+            .x = 100,
+            .y = 100
+          },
+          metil_direction_up
+        );
+
+        break;
+      }
+    }
+
+    metil_object_buffers_initialize(
+      metil_object,
+      metil->renderer_interface.metal_device
+    );
+
+    float percentage = (
+      (float) index_renderable / 
+      (float) (
+        metil_scene->length_renderables -
+        1
+      )
+    );
+
+    metil_object->position.x = percentage * width - width / 2.0f;
+    metil_object->position.y = 10.0f;
+
+    metil_object->rotation.x = (
+      index_renderable *
+      math_c_pi
+    );
+
+    metil_object->rotation.y = (
+      index_renderable *
+      math_c_pi_half
+    );
+
+    struct metil_renderer_data_object* data_object = (
+      metil_object->buffers_vertex[
+        metil_object_buffer_default_index_data
+      ].buffer.contents
+    );
+  }
+
+  metil_scene->player.position.z = -100.0f;
+}
+
+void example_animation_scene_poll(
+  struct metil* metil,
+  struct metil_scene* metil_scene
+) {
+  metil_scene_poll_default(
+    metil,
+    metil_scene
+  );
+
+  for (
+    unsigned int index_renderable = 0;
+    index_renderable < metil_scene->length_renderables;
+    ++index_renderable
+  ) {
+    struct metil_object* metil_object = (
+      metil_scene->renderables[
+        index_renderable
+      ].renderable
+    );
+
+    metil_animation_poll(
+      &an[index_renderable],
+      metil_renderable_type_object,
+      metil_object
+    );
+  }
+}

--- a/include/metil_animation/metil_animation.h
+++ b/include/metil_animation/metil_animation.h
@@ -1,0 +1,98 @@
+#ifndef __metil_animation_metil_animation_h
+#define __metil_animation_metil_animation_h
+
+#include <metil_rendering/metil_renderable_type.h>
+#include <metil_utilities/metil_stopwatch.h>
+
+#include <sys/time.h>
+
+struct metil_animation;
+
+typedef void (*metil_animation_function_start)(
+  struct metil_animation*,
+  enum metil_renderable_type,
+  void*
+);
+
+typedef void (*metil_animation_function_poll)(
+  struct metil_animation*,
+  enum metil_renderable_type,
+  void*,
+  float
+);
+
+typedef void (*metil_animation_function_end)(
+  struct metil_animation*,
+  enum metil_renderable_type,
+  void*
+);
+
+enum metil_animation_direction {
+  metil_animation_direction_backwards = 0x00,
+  metil_animation_direction_forwards = 0xff
+};
+
+enum metil_animation_loop {
+  metil_animation_loop_none = 0b00000000,
+  metil_animation_loop_loops = 0b00000001,
+  metil_animation_loop_loops_mirrored = 0b00000011,
+};
+
+enum metil_animation_state {
+  metil_animation_state_inactive = 0x00,
+  metil_animation_state_starting = 0x01,
+  metil_animation_state_restarting = 0x02,
+  metil_animation_state_active = 0x03,
+  metil_animation_state_pausing = 0x04,
+  metil_animation_state_paused = 0x05,
+  metil_animation_state_unpausing = 0x06,
+  metil_animation_state_complete = 0xff
+};
+
+struct metil_animation {
+  metil_animation_function_start start;
+  metil_animation_function_poll poll;
+  metil_animation_function_end end;
+
+  enum metil_animation_direction direction;
+  enum metil_animation_loop loops;
+  enum metil_animation_state state;
+
+  struct metil_stopwatch stopwatch;
+  unsigned long int length;
+  struct timeval timevalue_paused;
+
+  void* data;
+};
+
+void metil_animation_initialize(
+  struct metil_animation*
+);
+
+void metil_animation_start(
+  struct metil_animation*,
+  enum metil_renderable_type,
+  void*
+);
+
+void metil_animation_poll(
+  struct metil_animation*,
+  enum metil_renderable_type,
+  void*
+);
+
+void metil_animation_end(
+  struct metil_animation*,
+  enum metil_renderable_type,
+  void*
+);
+
+void metil_animation_pause(
+  struct metil_animation*
+);
+
+void metil_animation_resume(
+  struct metil_animation*
+);
+
+#endif

--- a/sources/metil_animation/metil_animation.c
+++ b/sources/metil_animation/metil_animation.c
@@ -1,0 +1,224 @@
+#include <metil_animation/metil_animation.h>
+
+#include <metil_utilities/metil_stopwatch.h>
+
+void metil_animation_initialize(
+  struct metil_animation* metil_animation
+) {
+  metil_animation->start = 0;
+  metil_animation->poll = 0;
+  metil_animation->end = 0;
+
+  metil_animation->direction = (
+    metil_animation_direction_forwards
+  );
+
+  metil_animation->loops = (
+    metil_animation_loop_loops_mirrored
+  );
+
+  metil_animation->state = (
+    metil_animation_state_inactive
+  );
+
+  metil_animation->length = (
+    1000
+  );
+
+  metil_animation->data = 0;
+}
+
+void metil_animation_start(
+  struct metil_animation* metil_animation,
+  enum metil_renderable_type metil_renderable_type,
+  void* metil_renderable
+) {
+  metil_stopwatch_start(
+    &metil_animation->stopwatch
+  );
+
+  if (
+    metil_animation->start != 0
+  ) {
+    metil_animation->start(
+      metil_animation,
+      metil_renderable_type,
+      metil_renderable
+    );
+  }
+
+  metil_animation->state = (
+    metil_animation_state_active
+  );
+}
+
+void metil_animation_poll(
+  struct metil_animation* metil_animation,
+  enum metil_renderable_type metil_renderable_type,
+  void* metil_renderable
+) {
+
+  switch (
+    metil_animation->state
+  ) {
+    case metil_animation_state_starting:
+    case metil_animation_state_restarting: {
+      metil_animation_start(
+        metil_animation,
+        metil_renderable_type,
+        metil_renderable
+      );
+
+      break;
+    }
+    case metil_animation_state_pausing: {
+      metil_animation_pause(
+        metil_animation
+      );
+
+      return;
+    }
+    case metil_animation_state_unpausing: {
+      metil_animation_resume(
+        metil_animation
+      );
+      
+      break;
+    }
+    case metil_animation_state_active: {
+      break;
+    }
+    default: {
+      return;
+    }
+  }
+
+  float percentage_complete = (
+    (float) metil_stopwatch_elapsed(
+      &metil_animation->stopwatch
+    ) /
+    (float) metil_animation->length
+  );
+
+  if (
+    percentage_complete >= 1.0f
+  ) {
+    metil_animation_end(
+      metil_animation,
+      metil_renderable_type,
+      metil_renderable
+    );
+  } else if (
+    metil_animation->poll != 0
+  ) {
+    if (
+      metil_animation->direction == metil_animation_direction_backwards
+    ) {
+      percentage_complete = (
+        1.0f -
+        percentage_complete
+      );
+    }
+    
+    metil_animation->poll(
+      metil_animation,
+      metil_renderable_type,
+      metil_renderable,
+      percentage_complete
+    );
+  }
+}
+
+void metil_animation_end(
+  struct metil_animation* metil_animation,
+  enum metil_renderable_type metil_renderable_type,
+  void* metil_renderable
+) {
+  if (
+    metil_animation->end != 0
+  ) {
+    metil_animation->end(
+      metil_animation,
+      metil_renderable_type,
+      metil_renderable
+    );
+  }
+
+  if (
+    metil_animation->loops == metil_animation_loop_none
+  ) {
+    metil_animation->state = (
+      metil_animation_state_complete
+    );
+  } else if (
+    (
+      metil_animation->loops &
+      metil_animation_loop_loops
+    ) != 0
+  ) {
+    metil_animation->state = (
+      metil_animation_state_restarting
+    );
+
+    if (
+      (
+        metil_animation->loops &
+        metil_animation_loop_loops_mirrored
+      ) == (
+        metil_animation_loop_loops_mirrored
+      )
+    ) {
+      metil_animation->direction = (
+        metil_animation->direction ^ 0xff
+      );
+    }
+
+    metil_animation_poll(
+      metil_animation,
+      metil_renderable_type,
+      metil_renderable
+    );
+  }
+}
+
+void metil_animation_pause(
+  struct metil_animation* metil_animation
+) {
+  metil_animation->state = (
+    metil_animation_state_paused
+  );
+
+  metil_animation->timevalue_paused.tv_sec = (
+    metil_animation->stopwatch.timeval.tv_sec
+  );
+
+  metil_animation->timevalue_paused.tv_usec = (
+    metil_animation->stopwatch.timeval.tv_usec
+  );
+}
+
+void metil_animation_resume(
+  struct metil_animation* metil_animation
+) {
+  metil_animation->state = (
+    metil_animation_state_active
+  );
+
+  metil_stopwatch_start(
+    &metil_animation->stopwatch
+  );
+
+  metil_animation->stopwatch.timeval.tv_sec = (
+    metil_animation->timevalue_paused.tv_sec + (
+      metil_animation->stopwatch.timeval.tv_sec -
+      metil_animation->timevalue_paused.tv_sec
+    )
+  );
+
+  metil_animation->stopwatch.timeval.tv_usec = (
+    metil_animation->timevalue_paused.tv_usec + (
+      metil_animation->stopwatch.timeval.tv_usec -
+      metil_animation->timevalue_paused.tv_usec
+    )
+  );
+}


### PR DESCRIPTION
- `metil_animation`:add
- - will be integrating this further into rendering, may make it attatched to objects/models
- - technically this can be used with any data type, not just renderables, like you could just pass a mesh and a value of `0x00` to the type parameter and use it that way.
- - the type parameter is just in case an animation is used by more than one renderable type.
- - that may change later on, idk.
- `examples/animation`:add_preliminary
- - this example is a mess, i'll change this later


https://github.com/user-attachments/assets/814d01ba-ee2d-44ad-922e-30cac43920db


