### PR TITLE
[enh] `metil_mesh_line`:add

### DIFF
--- a/include/metil_mesh/metil_mesh_line.h
+++ b/include/metil_mesh/metil_mesh_line.h
@@ -1,0 +1,14 @@
+#ifndef __metil_metil_mesh_metil_mesh_line_h
+#define __metil_metil_mesh_metil_mesh_line_h
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <math_c_vector.h>
+
+void metil_mesh_line_initialize(
+  struct metil_mesh*,
+  unsigned int,
+  struct math_c_vector3_float*
+);
+
+#endif

--- a/sources/metil_mesh/metil_mesh_line.c
+++ b/sources/metil_mesh/metil_mesh_line.c
@@ -1,0 +1,249 @@
+#include <metil_mesh/metil_mesh_line.h>
+
+#include <metil_mesh/metil_mesh.h>
+
+#include <clic3_memory.h>
+
+#include <math_c_vector.h>
+
+void metil_mesh_line_initialize(
+  struct metil_mesh* metil_mesh_line,
+  unsigned int length_points,
+  struct math_c_vector3_float* points
+) {
+  metil_mesh_initialize(
+    metil_mesh_line
+  );
+
+  metil_mesh_line->length_indices = (
+    (
+      length_points -
+      1
+    ) *
+    2
+  );
+
+  metil_mesh_line->length_vertices = (
+    length_points
+  );
+
+  clic3_memory_reallocate_raw(
+    &metil_mesh_line->indices,
+    (
+      sizeof(
+        unsigned int
+      ) *
+      metil_mesh_line->length_indices
+    )
+  );
+
+  clic3_memory_reallocate_raw(
+    &metil_mesh_line->vertices,
+    (
+      sizeof(
+        struct math_c_vector4_float
+      ) *
+      metil_mesh_line->length_vertices
+    )
+  );
+
+  unsigned int index_index = 0;
+
+  struct math_c_vector3_float size_minimums = {
+    .x = (
+      points[
+        0
+      ].x
+    ),
+    .y = (
+      points[
+        0
+      ].y
+    ),
+    .z = (
+      points[
+        0
+      ].z
+    )
+  };
+
+  struct math_c_vector3_float size_maximums = {
+    .x = (
+      points[
+        0
+      ].x
+    ),
+    .y = (
+      points[
+        0
+      ].y
+    ),
+    .z = (
+      points[
+        0
+      ].z
+    )
+  };
+
+  for (
+    unsigned int index_vertex = 0;
+    index_vertex < length_points;
+    ++index_vertex
+  ) {
+    metil_mesh_line->vertices[
+      index_vertex
+    ].x = (
+      points[
+        index_vertex
+      ].x
+    );
+
+    metil_mesh_line->vertices[
+      index_vertex
+    ].y = (
+      points[
+        index_vertex
+      ].y
+    );
+
+    metil_mesh_line->vertices[
+      index_vertex
+    ].z = (
+      points[
+        index_vertex
+      ].z
+    );
+
+    metil_mesh_line->vertices[
+      index_vertex
+    ].w = (
+      1.0f
+    );
+
+    if (
+      index_vertex > 0
+    ) {
+      if (
+        size_minimums.x > (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].x
+        )
+      ) {
+        size_minimums.x = (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].x
+        );
+      }
+
+      if (
+        size_minimums.y > (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].y
+        )
+      ) {
+        size_minimums.y = (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].y
+        );
+      }
+
+      if (
+        size_minimums.z > (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].z
+        )
+      ) {
+        size_minimums.z = (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].z
+        );
+      }
+
+      if (
+        size_maximums.x < (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].x
+        )
+      ) {
+        size_maximums.x = (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].x
+        );
+      }
+
+      if (
+        size_maximums.y < (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].y
+        )
+      ) {
+        size_maximums.y = (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].y
+        );
+      }
+
+      if (
+        size_maximums.z < (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].z
+        )
+      ) {
+        size_maximums.z = (
+          metil_mesh_line->vertices[
+            index_vertex
+          ].z
+        );
+      }
+
+      metil_mesh_line->indices[
+        index_index
+      ] = (
+        index_vertex -
+        1
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+
+      metil_mesh_line->indices[
+        index_index
+      ] = (
+        index_vertex
+      );
+
+      index_index = (
+        index_index +
+        1
+      );
+    }
+  }
+
+  metil_mesh_line->size.x = (
+    size_maximums.x -
+    size_minimums.x
+  );
+
+  metil_mesh_line->size.y = (
+    size_maximums.y -
+    size_minimums.y
+  );
+
+  metil_mesh_line->size.z = (
+    size_maximums.z -
+    size_minimums.z
+  );
+}


### PR DESCRIPTION
- `metil_mesh_line`:add
- - use with `MTLPrimitiveTypeLine` or `MTLPrimitiveTypeLineStrip` set on `metil_object->type_primitive`

## example

```obj-c
struct metil_object* metil_object = (
  scene->renderables[
    0
  ].renderable
);

struct math_c_vector3_float points[5] = {
  {
    .x = -10.0f,
    .y = -10.0f,
    .z = -8.0f
  },
  {
    .x = 0.0f,
    .y = 10.0f,
    .z = -5.0f
  },
  {
    .x = 10.0f,
    .y = -10.0f,
    .z = -2.0f
  },
  {
    .x = 11.0f,
    .y = 0.0f,
    .z = -6.0f
  },
  {
    .x = -21.0f,
    .y = 0.0f,
    .z = -4.0f
  }
};

metil_mesh_line_initialize(
  &metil_object->mesh,
  5,
  points
);

metil_object->type_primitive = MTLPrimitiveTypeLine;

metil_object_buffers_initialize(
  metil_object,
  metil->renderer_interface.metal_device
);
```

<img width="708" height="447" alt="Screenshot 2026-02-03 at 18 47 26" src="https://github.com/user-attachments/assets/a24d9c39-6164-4c18-8293-48c18adf5ab4" />

https://github.com/user-attachments/assets/bb6cb1db-0664-464c-8501-858778d272e7

