### PR TITLE
[dev|enh] `metil_text`:add_letter_width_styles

### DIFF
--- a/include/metil_text/metil_text.h
+++ b/include/metil_text/metil_text.h
@@ -15,9 +15,15 @@ struct metil_text_image {
   struct math_c_vector2_unsigned_int size;
 };
 
+#define metil_text_letter_spacing_style_default -1
+#define metil_text_letter_spacing_style_maximum -2
+
 struct metil_text_render_parameters {
   CTFontRef _Nonnull font;
+
+  short int letter_width;
   unsigned short int letter_spacing;
+  
   struct math_c_vector2_unsigned_short_int padding;
   float scale;
 };

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -82,10 +82,10 @@ int metil_initialize_with_data(
 
   metil_paths_initialize(
     &metil.paths,
-   (
-    (char*)
-    metil.parameters.parameters_proxied[0]
-   ),
+    (
+      (char*)
+      metil.parameters.parameters_proxied[0]
+    ),
     name
   );
 

--- a/sources/metil_text/metil_text.m
+++ b/sources/metil_text/metil_text.m
@@ -153,6 +153,33 @@ struct metil_text_image* metil_text_render(
 
   text_image->size.y = 0;
 
+  float spacing_width_maximum = 0;
+
+  if (
+    metil_text_render_parameters->letter_width ==
+    metil_text_letter_spacing_style_maximum
+  ) {
+    for (
+      unsigned char index_glyph = 0;
+      index_glyph < length_characters;
+      ++index_glyph
+    ) {
+      unsigned int width_glyph = (
+        bounding_box_glyphs[
+          index_glyph
+        ].size.width
+      );
+
+      if (
+        width_glyph > spacing_width_maximum
+      ) {
+        spacing_width_maximum = (
+          width_glyph
+        );
+      }
+    }
+  }
+
   for (
     unsigned char index_glyph = 0;
     index_glyph < length_characters;
@@ -170,11 +197,67 @@ struct metil_text_image* metil_text_render(
       metil_text_render_parameters->padding.y
     );
 
+    unsigned short int spacing_width = 0;
+
+    switch (
+      metil_text_render_parameters->letter_width
+    ) {
+      case metil_text_letter_spacing_style_default: {
+        spacing_width = (
+          bounding_box_glyphs[
+            index_glyph
+          ].size.width
+        );
+
+        break;
+      }
+      case metil_text_letter_spacing_style_maximum: {
+        spacing_width = (
+          spacing_width_maximum
+        );
+
+        positions_glyphs[
+          index_glyph
+        ].x = (
+          positions_glyphs[
+            index_glyph
+          ].x + (
+            spacing_width_maximum -
+            bounding_box_glyphs[
+              index_glyph
+            ].size.width
+          ) /
+          2.0f
+        );
+
+        break;
+      }
+      default: {
+        spacing_width = (
+          metil_text_render_parameters->letter_width
+        );
+
+        positions_glyphs[
+          index_glyph
+        ].x = (
+          positions_glyphs[
+            index_glyph
+          ].x + (
+            metil_text_render_parameters->letter_width -
+            bounding_box_glyphs[
+              index_glyph
+            ].size.width
+          ) /
+          2.0f
+        );
+
+        break;
+      }
+    }
+
     text_image->size.x = (
       text_image->size.x +
-      bounding_box_glyphs[
-        index_glyph
-      ].size.width +
+      spacing_width +
       metil_text_render_parameters->letter_spacing
     );
 

--- a/sources/metil_text/metil_text_defaults.m
+++ b/sources/metil_text/metil_text_defaults.m
@@ -13,7 +13,11 @@ void metil_text_defaults_initialize(
     0
   );
 
-  metil_text_defaults->render_parameters.letter_spacing = 2;
+  metil_text_defaults->render_parameters.letter_width = (
+    metil_text_letter_spacing_style_default
+  );
+
+  metil_text_defaults->render_parameters.letter_spacing = 4;
     
   metil_text_defaults->render_parameters.padding.x = 5;
   metil_text_defaults->render_parameters.padding.y = 15;
@@ -21,7 +25,7 @@ void metil_text_defaults_initialize(
   metil_text_defaults->render_parameters.scale = 0.001f;
 
   CFStringRef name_family_font_monospace = CFSTR(
-    "monospace"
+    "Monaco"
   );
 
   metil_text_defaults->render_parameters.font = CTFontCreateWithName(


### PR DESCRIPTION
- `metil_text_letter_spacing_style` defines add
- `struct metil_text_render_parameters`:add->{`letter_width`};
- set default font to `Monaco`
- set default letter spacing to `4`

heres some different combinations of letter widths and spacings i dont remember which is which.

<img width="617" height="64" alt="Screenshot 2026-02-03 at 20 06 11" src="https://github.com/user-attachments/assets/e202fac4-c849-4491-8bcb-8f43cd6d25e7" />
<img width="513" height="48" alt="Screenshot 2026-02-03 at 20 06 44" src="https://github.com/user-attachments/assets/ca5e0a7c-e9b9-4574-87f4-eefee9265889" />
<img width="599" height="45" alt="Screenshot 2026-02-03 at 20 07 24" src="https://github.com/user-attachments/assets/7d0ebc97-2eaa-46c1-8377-6eb16f68f6ab" />
<img width="1420" height="84" alt="Screenshot 2026-02-03 at 20 09 04" src="https://github.com/user-attachments/assets/bf567ba6-3b01-460d-b2e6-de4413bad5df" />


## letter_width

`metil_text_letter_spacing_style_default` spaces each letter out by the glyph size + letter spacing
`metil_text_letter_spacing_style_maximum` spaces each letter out to be centered within the maximum glyph width then adds letter spacing
any value that's not `-1` or `-2` will be used as the width amount with the same sizing/spacing calculations as `metil_text_letter_spacing_style_maximum` except the width used will be whatever the value is set to

1. i should make this a float instead, dont care
2. `metil_text_letter_spacing_style_%` should be named `metil_text_letter_width_style_`, also dont care
3. maybe i'll update that in the future. idk.
