### PR TITLE
[enh] `metil_player`:add_dead_zone_for_left_stick

### DIFF
--- a/sources/metil_player/metil_player.m
+++ b/sources/metil_player/metil_player.m
@@ -291,8 +291,10 @@ void metil_player_poll_input(
 
   if (
     metil->input.controller_state.available == 1 &&
-    metil->input.controller_state.left_stick.x != 0.0f ||
-    metil->input.controller_state.left_stick.y != 0.0f
+    metil->input.controller_state.left_stick.x >= metil_player->deadzone_stick ||
+    metil->input.controller_state.left_stick.x <= -metil_player->deadzone_stick ||
+    metil->input.controller_state.left_stick.y >= metil_player->deadzone_stick ||
+    metil->input.controller_state.left_stick.y <= -metil_player->deadzone_stick
   ) {
     movement.x = (
       (metil->input.controller_state.left_stick.y * ratio_movement.x) +
@@ -425,7 +427,7 @@ void metil_player_poll_input(
     (
       metil->input.keydown_map[
         metil_keycode_space
-      ] == 1 ||(
+      ] == 1 || (
         metil->input.controller_state.available == 1 &&
         metil->input.controller_state.cross >= 0.1f
       )


### PR DESCRIPTION
this isn't needed on my end, my left stick is always zeroed out at rest, but like, yeah, idk. here's a deadzone for it. ill make these configurable later