### PR TITLE
[bug|enh] `metil_camera`:: updates

### DIFF
--- a/include/metil_rendering/metil_camera/metil_camera.h
+++ b/include/metil_rendering/metil_camera/metil_camera.h
@@ -13,7 +13,6 @@
 struct metil_camera {
   enum metil_camera_mode mode;
 
-  float ratio_aspect;
   float ratio_aspect_view;
 
   float height_default;

--- a/include/metil_rendering/metil_camera/metil_camera.h
+++ b/include/metil_rendering/metil_camera/metil_camera.h
@@ -2,7 +2,6 @@
 #define __metil_rendering_metil_camera_metil_camera_h
 
 #include <metil_rendering/metil_camera/metil_camera_mode.h>
-#include <metil_rendering/metil_camera/metil_lens.h>
 #include <metil_rendering/metil_camera/metil_near_far.h>
 
 #include <math_c_vector.h>
@@ -13,8 +12,6 @@
 
 struct metil_camera {
   enum metil_camera_mode mode;
-
-  struct metil_lens lens;
 
   float ratio_aspect;
   float ratio_aspect_view;
@@ -38,20 +35,24 @@ void metil_camera_initialize(
 
 void metil_camera_ratio_aspect_set(
   struct metil_camera*,
-  float,
-  float,
-  float
+  struct math_c_vector2_float*
+);
+
+void metil_camera_normalization_set(
+  struct metil_camera*
 );
 
 float metil_camera_field_of_view_calculate(
-  struct metil_camera*
-);
-
-float metil_camera_field_of_view_horizontal_calculate(
-  struct metil_camera*
+  struct metil_camera*,
+  struct math_c_vector2_float
 );
 
 void metil_camera_field_of_view_set(
+  struct metil_camera*,
+  struct math_c_vector2_float
+);
+
+void metil_camera_matrix_projection_set(
   struct metil_camera*
 );
 

--- a/include/metil_rendering/metil_camera/metil_lens.h
+++ b/include/metil_rendering/metil_camera/metil_lens.h
@@ -1,9 +1,0 @@
-#ifndef __metil_rendering_metil_camera_metil_lens_h
-#define __metil_rendering_metil_camera_metil_lens_h
-
-struct metil_lens {
-  float length_focal;
-  float size_sensor;
-};
-
-#endif

--- a/sources/metil_rendering/metil_camera/metil_camera.c
+++ b/sources/metil_rendering/metil_camera/metil_camera.c
@@ -31,106 +31,110 @@ void metil_camera_initialize(
   metil_camera->distance_view.near = 0.5f;
   metil_camera->distance_view.far = 10000.0f;
 
-  metil_camera->lens.length_focal = 10.0f;
-  metil_camera->lens.size_sensor = 10.0f;
-
   metil_camera->matrix_viewport_projection = (simd_float4x4) {{
-    { 0.0f, 0.0f, 0.0f, 0.0f },
-    { 0.0f, 0.0f, 0.0f, 0.0f },
-    { 0.0f, 0.0f, 0.0f, -1.0f },
-    { 0.0f, 0.0f, 0.0f, 0.0f }
+    { 1.0f, 0.0f, 0.0f, 0.0f },
+    { 0.0f, 1.0f, 0.0f, 0.0f },
+    { 0.0f, 0.0f, 1.0f, -1.0f },
+    { 0.0f, 0.0f, 0.0f, 1.0f }
   }};
 }
 
 void metil_camera_ratio_aspect_set(
   struct metil_camera* metil_camera,
-  float ratio_aspect,
-  float width,
-  float height
+  struct math_c_vector2_float* metil_camera_size_view
 ) {
-  metil_camera->ratio_aspect = ratio_aspect;
   metil_camera->ratio_aspect_view = (
-    width /
-    height
+    metil_camera_size_view->x /
+    metil_camera_size_view->y
   );
 
   metil_camera_field_of_view_set(
-    metil_camera
-  );
-}
-
-float metil_camera_field_of_view_calculate(
-  struct metil_camera* metil_camera
-) {
-  return (
-    2.0f * atanf(
-      metil_camera->lens.size_sensor / (
-        2.0f *
-        metil_camera->lens.length_focal
-      )
-    )
-  );
-}
-
-float metil_camera_field_of_view_horizontal_calculate(
-  struct metil_camera* metil_camera
-) {
-  return (
-    metil_camera->field_of_view.y *
-    metil_camera->ratio_aspect
+    metil_camera,
+    (struct math_c_vector2_float) {
+      .x = 0.9f,
+      .y = 0.9f
+    }
   );
 }
 
 void metil_camera_field_of_view_set(
+  struct metil_camera* metil_camera,
+  struct math_c_vector2_float metil_camera_field_of_view
+) {
+  metil_camera->field_of_view.x = (
+    metil_camera_field_of_view.x
+  );
+
+  metil_camera->field_of_view.y = (
+    metil_camera_field_of_view.y
+  );
+
+  metil_camera_normalization_set(
+    metil_camera
+  );
+}
+
+void metil_camera_normalization_set(
   struct metil_camera* metil_camera
 ) {
-  metil_camera->field_of_view.y = (
-    metil_camera_field_of_view_calculate(
-      metil_camera
-    )
-  );
-
-  metil_camera->field_of_view.x = (
-    metil_camera_field_of_view_horizontal_calculate(
-      metil_camera
-    )
-  );
-
   metil_camera->vector_normalization.x = (
-    1.0f /
-    metil_camera->field_of_view.x
+    (
+      1.0f /
+      (
+        metil_camera->field_of_view.x /
+        metil_camera->ratio_aspect_view /
+        metil_camera->ratio_aspect_view
+      ) /
+      metil_camera->ratio_aspect_view
+    ) *
+    (
+      1.0f /
+      metil_camera->ratio_aspect_view
+    )
   );
 
   metil_camera->vector_normalization.y = (
     1.0f /
-    metil_camera->field_of_view.y
+    (
+      metil_camera->field_of_view.y /
+      metil_camera->ratio_aspect_view /
+      metil_camera->ratio_aspect_view
+    ) /
+    metil_camera->ratio_aspect_view
   );
 
   metil_camera->vector_normalization.z = (
-    metil_camera->distance_view.far / (
+    metil_camera->distance_view.near *
+    metil_camera->distance_view.far /
+    (
       metil_camera->distance_view.near -
       metil_camera->distance_view.far
     )
   );
 
-  // TODO: This keeps objects sized properly, however, it also increases the FOV when Y shrinks. Will fix this later.
-  metil_camera->matrix_viewport_projection.columns[0].x = (
-    metil_camera->vector_normalization.x * (
-      metil_camera->ratio_aspect /
-      metil_camera->ratio_aspect_view
-    )
+  metil_camera_matrix_projection_set(
+    metil_camera
+  );
+}
+
+void metil_camera_matrix_projection_set(
+  struct metil_camera* metil_camera
+) {
+   metil_camera->matrix_viewport_projection.columns[
+    0
+  ].x = (
+    metil_camera->vector_normalization.x
   );
 
-  metil_camera->matrix_viewport_projection.columns[1].y = (
+  metil_camera->matrix_viewport_projection.columns[
+    1
+  ].y = (
     metil_camera->vector_normalization.y
   );
 
-  metil_camera->matrix_viewport_projection.columns[2].z = (
-    metil_camera->vector_normalization.z
-  );
-
-  metil_camera->matrix_viewport_projection.columns[3].z = (
-    metil_camera->distance_view.near *
+  metil_camera->matrix_viewport_projection.columns[
+    2
+  ].z = (
     metil_camera->vector_normalization.z
   );
 }

--- a/sources/metil_rendering/metil_camera/metil_camera.c
+++ b/sources/metil_rendering/metil_camera/metil_camera.c
@@ -11,8 +11,8 @@ void metil_camera_initialize(
     metil_camera_mode_first_person
   );
 
-  metil_camera->field_of_view.x = 0.0f;
-  metil_camera->field_of_view.y = 0.0f;
+  metil_camera->field_of_view.x = 1.45f;
+  metil_camera->field_of_view.y = 1.45f;
 
   if (
     metil_camera->initialized == 0
@@ -48,12 +48,8 @@ void metil_camera_ratio_aspect_set(
     metil_camera_size_view->y
   );
 
-  metil_camera_field_of_view_set(
-    metil_camera,
-    (struct math_c_vector2_float) {
-      .x = 0.9f,
-      .y = 0.9f
-    }
+  metil_camera_normalization_set(
+    metil_camera
   );
 }
 

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -604,7 +604,7 @@
   ][
     0
   ] = (
-    self->metil->rendering_properties.camera.ratio_aspect /
+    1.0f /
     self->metil->rendering_properties.camera.ratio_aspect_view
   );
 }

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -586,20 +586,24 @@
     1920x1203 is fine
     1920x1202 causes slow down
   */
-  self->metil->renderer_interface.size.x = size.width;
-  self->metil->renderer_interface.size.y = size.height;
+  self->metil->renderer_interface.size.x = (
+    size.width
+  );
+
+  self->metil->renderer_interface.size.y = (
+    size.height
+  );
 
   metil_camera_ratio_aspect_set(
     &self->metil->rendering_properties.camera,
-    (
-      16 /
-      9
-    ),
-    self->metil->renderer_interface.size.x,
-    self->metil->renderer_interface.size.y
+    &self->metil->renderer_interface.size
   );
 
-  self->matrix_projection_static.columns[0][0] = (
+  self->matrix_projection_static.columns[
+    0
+  ][
+    0
+  ] = (
     self->metil->rendering_properties.camera.ratio_aspect /
     self->metil->rendering_properties.camera.ratio_aspect_view
   );


### PR DESCRIPTION
- `metil_camera`:properly calculate fov
- - horizontal fov stays locked to the same value across resizes
- - vertical fov scales with height changes

before a fov of 90 degrees was actually closer to 145 degrees

i set the default to 145 degrees since that's what i'm used to

ill make this a config option at some point

## original at "90" fov

<img width="1966" height="1250" alt="Screenshot 2026-02-08 at 20 25 06" src="https://github.com/user-attachments/assets/70176ec7-43a3-4660-b243-69e4c9f3da5b" />

## updated at 90 fov 

<img width="1966" height="1250" alt="Screenshot 2026-02-08 at 20 26 14" src="https://github.com/user-attachments/assets/458f2dcf-8265-4d4f-af61-58c774e50328" />

## updated at 145 fov

<img width="1966" height="1250" alt="Screenshot 2026-02-08 at 20 27 25" src="https://github.com/user-attachments/assets/9cdc3f9d-e514-458b-9264-cf0f073e65a1" />
