### PR TITLE
[bug] `metil_model`:fix_for_large_vertex_counts

### DIFF
--- a/sources/metil_model/metil_model.m
+++ b/sources/metil_model/metil_model.m
@@ -314,7 +314,8 @@ void metil_model_buffers_initialize(
 
     metil_object->buffers_vertex[
       metil_object_buffer_default_index_vertex_joint_map
-    ].buffer = [metal_device
+    ].buffer = [
+      metal_device
       newBufferWithBytes: (
         metil_model->vertex_joint_maps[
           index_object
@@ -326,7 +327,7 @@ void metil_model_buffers_initialize(
         ) *
         metil_object->mesh.length_vertices
       )
-      options: MTLResourceStorageModePrivate
+      options: MTLResourceStorageModeShared
     ];
 
     metil_object->buffers_vertex[


### PR DESCRIPTION
- `metil_model`:fix_for_large_vertex_counts

idk why `MTLResourceStorageModePrivate` segfaults with large amounts of vertices, but it does. somehow setting to `MTLResourceStorageModeShared` fixes it, not going to try to figure out why thats the case. havent seen performance differences either way