### PR TITLE
[enh] `metil_renderer_data_frames_length`:add

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -72,6 +72,7 @@
 - (void) command_queue_initialize;
 
 - (void) data_buffer_frames_initialize;
+- (void) data_buffer_frames_length_buffer_set: (unsigned int) length_buffer;
 
 - (void) descriptor_pipeline_render_initialize;
 

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -183,6 +183,38 @@
   }
 }
 
+- (void) data_buffer_frames_length_buffer_set:
+  (unsigned int) length_buffer
+{
+  for (
+    unsigned int index_buffer = (
+      0x00
+    );
+    (
+      index_buffer <
+      metil_count_max_frames
+    );
+    ++index_buffer
+  ) {
+    [
+      data_buffer_frame[
+        index_buffer
+      ]
+      release
+    ];
+
+    data_buffer_frame[
+      index_buffer
+    ] = [
+      self->metil->renderer_interface.metal_device
+      newBufferWithLength: (
+        length_buffer
+      )
+      options: MTLResourceStorageModeShared
+    ];
+  }
+}
+
 - (void) descriptor_pipeline_render_initialize {
   if (
     self->descriptor_pipeline_render == 0


### PR DESCRIPTION
- `metil_renderer_data_frames_length`:add
- - allows custom data_frame structures to be used