### PR TITLE
[dev] `metil_renderer`:set_renderer_poll_data_frame_to_public

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -60,7 +60,7 @@
 
   matrix_float3x4 matrix_projection_static;
 
-  metil_renderer_data_frame_poll_function poll_data_frame;
+  @public metil_renderer_data_frame_poll_function poll_data_frame;
 }
 
 - (nonnull instancetype) metil_renderer_initialize:


### PR DESCRIPTION
- `metil_renderer`:
- - set->{`poll_data_frame`}.to->{`@public`};