### PR TITLE
[dev] `metil_rendering_properties`:reduce_max_frames

### DIFF
--- a/include/metil_rendering/metil_rendering_properties.h
+++ b/include/metil_rendering/metil_rendering_properties.h
@@ -8,7 +8,7 @@
 
 #include <pthread.h>
 
-#define metil_count_max_frames 5
+#define metil_count_max_frames 1
 
 #define metil_count_time_frames 60
 


### PR DESCRIPTION
- `metil_rendering_properties`:reduce_max_frames
- - solves some weird issues where frames can end up out of order
- - may make this a parameter later on