### PR TITLE
[enh] `metil_initialization_parameters`:add

### DIFF
--- a/include/metil.h
+++ b/include/metil.h
@@ -3,6 +3,7 @@
 
 #include <metil_audio/metil_audio_data.h>
 #include <metil_configuration/metil_configuration.h>
+#include <metil_initialize/metil_initialization_parameters.h>
 #include <metil_input/metil_input.h>
 #include <metil_library.h>
 #include <metil_parameters.h>
@@ -18,11 +19,14 @@
 
 struct metil;
 
-typedef void (*metil_destroy_function)(struct metil* _Nonnull);
+typedef void (*metil_destroy_function)(
+  struct metil* _Nonnull
+);
 
 struct metil {
   struct metil_audio_data audio;
   struct metil_configuration configuration;
+  struct metil_initialization_parameters initialization_parameters;
   struct metil_input input;
   struct metil_library library;
   struct metil_parameters parameters;

--- a/include/metil_initialize.h
+++ b/include/metil_initialize.h
@@ -1,6 +1,7 @@
 #ifndef __metil_initialize_h
 #define __metil_initialize_h
 
+#include <metil_initialize/metil_initialization_parameters.h>
 #include <metil_rendering/metil_renderer.h>
 
 int metil_initialize(
@@ -14,6 +15,18 @@ int metil_initialize(
   metil_renderer_on_initialize_function
 );
 
+int metil_initialize_with_parameters(
+  int,
+  #if target_os_ios
+  char**,
+  #else
+  const char**,
+  #endif
+  char*,
+  metil_renderer_on_initialize_function,
+  struct metil_initialization_parameters*
+);
+
 int metil_initialize_with_data(
   int,
   #if target_os_ios
@@ -24,6 +37,19 @@ int metil_initialize_with_data(
   char*,
   metil_renderer_on_initialize_function,
   void*
+);
+
+int metil_initialize_with_parameters_with_data(
+  int,
+  #if target_os_ios
+  char**,
+  #else
+  const char**,
+  #endif
+  char*,
+  metil_renderer_on_initialize_function,
+  void*,
+  struct metil_initialization_parameters*
 );
 
 #endif

--- a/include/metil_initialize/metil_initialization_parameters.h
+++ b/include/metil_initialize/metil_initialization_parameters.h
@@ -1,0 +1,17 @@
+#ifndef __metil_initialize_metil_initialization_parameters_h
+#define __metil_initialize_metil_initialization_parameters_h
+
+struct metil_initialization_parameters {
+  unsigned char disabled_audio;
+};
+
+void metil_initialization_parameters_initialize(
+  struct metil_initialization_parameters*
+);
+
+void metil_initialization_parameters_clone(
+  struct metil_initialization_parameters*,
+  struct metil_initialization_parameters*
+);
+
+#endif

--- a/sources/metil.m
+++ b/sources/metil.m
@@ -16,7 +16,7 @@ void metil_structure_initialize(
   struct metil* metil
 ) {
   metil->text_defaults.object_text_index_pipeline_render = (
-    0
+    0x00
   );
 
   metil_player_defaults_initialize(
@@ -32,11 +32,11 @@ void metil_structure_initialize(
   );
 
   metil->data = (
-    0
+    0x00
   );
 
   metil->destroy = (
-    0
+    0x00
   );
 }
 
@@ -58,10 +58,15 @@ void metil_destroy(
     &metil->paths
   );
 
-  metil_audio_destroy(
-    &metil->audio,
-    &metil->configuration
-  );
+  if (
+    metil->initialization_parameters.disabled_audio ==
+    0x00
+  ) {
+    metil_audio_destroy(
+      &metil->audio,
+      &metil->configuration
+    );
+  }
 
   metil_text_destroy(
     &metil->text_defaults.render_parameters
@@ -76,7 +81,8 @@ void metil_destroy(
   );
 
   if (
-    metil->destroy != 0
+    metil->destroy !=
+    0x00
   ) {
     metil->destroy(
       metil

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -7,6 +7,7 @@
 #include <metil_configuration/metil_configuration.h>
 #include <metil_configuration/metil_configuration_values_set.h>
 #include <metil_debug/metil_debug_log.h>
+#include <metil_initialize/metil_initialization_parameters.h>
 #include <metil_input/metil_input.h>
 #include <metil_library.h>
 #include <metil_parameters.h>
@@ -41,12 +42,38 @@ int metil_initialize(
   char* name,
   metil_renderer_on_initialize_function metil_renderer_on_initialize_function
 ) {
-  return metil_initialize_with_data(
-    length_parameters,
-    parameters,
-    name,
-    metil_renderer_on_initialize_function,
-    0
+  return (
+    metil_initialize_with_parameters_with_data(
+      length_parameters,
+      parameters,
+      name,
+      metil_renderer_on_initialize_function,
+      0x00,
+      0x00
+    )
+  );
+}
+
+int metil_initialize_with_parameters(
+  int length_parameters,
+  #if target_os_ios
+  char** parameters,
+  #else
+  const char** parameters,
+  #endif
+  char* name,
+  metil_renderer_on_initialize_function metil_renderer_on_initialize_function,
+  struct metil_initialization_parameters* metil_initialization_parameters
+) {
+  return (
+    metil_initialize_with_parameters_with_data(
+      length_parameters,
+      parameters,
+      name,
+      metil_renderer_on_initialize_function,
+      0x00,
+      metil_initialization_parameters
+    )
   );
 }
 
@@ -61,11 +88,49 @@ int metil_initialize_with_data(
   metil_renderer_on_initialize_function metil_renderer_on_initialize_function,
   void* metil_renderer_on_initialize_function_data
 ) {
+  return (
+    metil_initialize_with_parameters_with_data(
+      length_parameters,
+      parameters,
+      name,
+      metil_renderer_on_initialize_function,
+      metil_renderer_on_initialize_function_data,
+      0x00
+    )
+  );
+}
+
+int metil_initialize_with_parameters_with_data(
+  int length_parameters,
+  #if target_os_ios
+  char** parameters,
+  #else
+  const char** parameters,
+  #endif
+  char* name,
+  metil_renderer_on_initialize_function metil_renderer_on_initialize_function,
+  void* metil_renderer_on_initialize_function_data,
+  struct metil_initialization_parameters* metil_initialization_parameters
+) {
   static struct metil metil;
 
   metil_structure_initialize(
     &metil
   );
+
+  if (
+    metil_initialization_parameters !=
+    0x00
+  ) {
+    metil_initialization_parameters_clone(
+      &metil.initialization_parameters,
+      metil_initialization_parameters
+    );
+  } else {
+    metil_initialization_parameters_initialize(
+      &metil.initialization_parameters
+    );
+  }
 
   metil_parameters_initialize(
     &metil.parameters,
@@ -163,10 +228,15 @@ int metil_initialize_with_data(
     metil.scene_controller
   );
 
-  metil_audio_initialize(
-    &metil,
-    &metil.audio
-  );
+  if (
+    metil.initialization_parameters.disabled_audio ==
+    0x00
+  ) {
+    metil_audio_initialize(
+      &metil,
+      &metil.audio
+    );
+  }
 
   metil_text_defaults_initialize(
     &metil.text_defaults,

--- a/sources/metil_initialize/metil_initialization_parameters.c
+++ b/sources/metil_initialize/metil_initialization_parameters.c
@@ -1,0 +1,23 @@
+#include <metil_initialize/metil_initialization_parameters.h>
+
+#include <clic3_bytes.h>
+
+void metil_initialization_parameters_initialize(
+  struct metil_initialization_parameters* metil_initialization_parameters
+) {
+  metil_initialization_parameters->disabled_audio = (
+    0x00
+  );  }
+
+void metil_initialization_parameters_clone(
+  struct metil_initialization_parameters* metil_initialization_parameters_target,
+  struct metil_initialization_parameters* metil_initialization_parameters_source
+) {
+  clic3_bytes_copy(
+    metil_initialization_parameters_target,
+    metil_initialization_parameters_source,
+    sizeof(
+      struct metil_initialization_parameters
+    )
+  );
+}

--- a/sources/metil_initialize/metil_initialization_parameters.c
+++ b/sources/metil_initialize/metil_initialization_parameters.c
@@ -7,7 +7,8 @@ void metil_initialization_parameters_initialize(
 ) {
   metil_initialization_parameters->disabled_audio = (
     0x00
-  );  }
+  );
+}
 
 void metil_initialization_parameters_clone(
   struct metil_initialization_parameters* metil_initialization_parameters_target,


### PR DESCRIPTION
- `metil_initialization_parameters`:add
- - `disabled_audio`:disables audio initialization and destroying
- - - useful for applications which dont need audio to prevent audio device switching