### PR TITLE
[dev] `metil_initialization_parameters`:fix_syntax_alignment

### DIFF
--- a/sources/metil_initialize/metil_initialization_parameters.c
+++ b/sources/metil_initialize/metil_initialization_parameters.c
@@ -7,7 +7,8 @@ void metil_initialization_parameters_initialize(
 ) {
   metil_initialization_parameters->disabled_audio = (
     0x00
-  );  }
+  );
+}
 
 void metil_initialization_parameters_clone(
   struct metil_initialization_parameters* metil_initialization_parameters_target,


### PR DESCRIPTION
- `metil_initialization_parameters`:fix_syntax_alignment