### PR TITLE
[dev] `metil_group`:add->{`metil_group_add_length_unallocated`};

### DIFF
--- a/include/metil_group.h
+++ b/include/metil_group.h
@@ -44,6 +44,11 @@ void metil_group_add_initialize(
   enum metil_renderable_type
 );
 
+void metil_group_add_length_unallocated(
+  struct metil_group* _Nonnull,
+  unsigned int
+);
+
 void metil_group_add_length_initialize(
   struct metil_group* _Nonnull,
   unsigned int,

--- a/sources/metil_group.m
+++ b/sources/metil_group.m
@@ -109,6 +109,51 @@ void metil_group_add_initialize(
   );
 }
 
+void metil_group_add_length_unallocated(
+  struct metil_group* metil_group,
+  unsigned int length
+) {
+  unsigned int index_renderable_starting = (
+    metil_group->length
+  );
+
+  metil_group->length = (
+    metil_group->length +
+    length
+  );
+
+  clic3_memory_reallocate_raw(
+    &metil_group->renderables,
+    (
+      sizeof(
+        struct metil_renderable*
+      ) *
+      metil_group->length
+    )
+  );
+
+  for (
+    unsigned int index_renderable = (
+      index_renderable_starting
+    );
+    (
+      index_renderable <
+      metil_group->length
+    );
+    ++index_renderable
+  ) {
+    metil_group->renderables[
+      index_renderable
+    ] = (
+      clic3_memory_allocate_raw(
+        sizeof(
+          struct metil_renderable
+        )
+      )
+    );
+  }
+}
+
 void metil_group_add_length_initialize(
   struct metil_group* metil_group,
   unsigned int length,


### PR DESCRIPTION
- `metil_group`
- - `metil_group_add_length_unallocated`
- - - adds length to the group and allocates the space for a renderable but not the actual renderable itself
- - - allows adding renderables to the group without needing a renderable type/function passed in
- - - the renderables[index]->renderable itself is unallocated but renderables[index] is not