### PR TITLE
[enh] `metil_audio_io_proc`:macros

### DIFF
--- a/include/metil_audio/metil_audio_io_proc.h
+++ b/include/metil_audio/metil_audio_io_proc.h
@@ -54,4 +54,138 @@ void metil_audio_io_proc_destroy(
   );
 #endif
 
+#if target_os_ios
+#define metil_audio_io_proc_macro_definition(name_metil_audio_io_proc)\
+  int name_metil_audio_io_proc(\
+    unsigned char silence,\
+    const AudioTimeStamp* _Nonnull timestamp,\
+    AVAudioFrameCount length_frames,\
+    AudioBufferList* _Nonnull output_data,\
+    void* data\
+  )
+#else
+#define metil_audio_io_proc_macro_definition(name_metil_audio_io_proc)\
+  OSStatus name_metil_audio_io_proc(\
+    AudioObjectID id_audio_object,\
+    const AudioTimeStamp* time_stamp_audio,\
+    const AudioBufferList* list_buffer_audio_in,\
+    const AudioTimeStamp* time_stamp_audio_in,\
+    AudioBufferList* list_buffer_audio_out,\
+    const AudioTimeStamp* time_stamp_audio_out,\
+    void* data\
+  )
+#endif
+
+#define metil_audio_io_proc_macro_definition_initializer\
+  struct metil_audio_io_proc_data* metil_audio_io_proc_data = (\
+    data\
+  );\
+\
+  struct metil* metil = (\
+    metil_audio_io_proc_data->metil\
+  );
+
+#if target_os_ios
+#define metil_audio_io_proc_macro_definition_frame_loop\
+  for (\
+    unsigned long int index_buffer = (\
+      0x00\
+    );\
+    (\
+      index_buffer <\
+      output_data->mNumberBuffers\
+    );\
+    ++index_buffer\
+  ) {\
+    AudioBuffer audio_buffer_current = (\
+      output_data->mBuffers[\
+        index_buffer\
+      ]\
+    );\
+\
+    float* buffer_out = (\
+      audio_buffer_current.mData\
+    );\
+\
+    unsigned long int length_channels = (\
+      audio_buffer_current.mNumberChannels\
+    );\
+\
+    for (\
+      unsigned int index_frame = (\
+        0x00\
+      );\
+      (\
+        index_frame <\
+        length_frames\
+      );\
+      ++index_frame\
+    )
+
+#else
+#define metil_audio_io_proc_macro_definition_frame_loop\
+  for (\
+    unsigned long int index_buffer = (\
+      0x00\
+    );\
+    (\
+      index_buffer <\
+      list_buffer_audio_out->mNumberBuffers\
+    );\
+    ++index_buffer\
+  ) {\
+    AudioBuffer audio_buffer_current = (\
+      list_buffer_audio_out->mBuffers[\
+        index_buffer\
+      ]\
+    );\
+\
+    float* buffer_out = (\
+      audio_buffer_current.mData\
+    );\
+\
+    unsigned long int length_frames = (\
+      audio_buffer_current.mDataByteSize /\
+      sizeof(\
+        float\
+      )\
+    );\
+\
+    unsigned long int length_channels = (\
+      audio_buffer_current.mNumberChannels\
+    );\
+\
+    for (\
+      unsigned long int index_frame = (\
+        0x00\
+      );\
+      (\
+        index_frame <\
+        length_frames\
+      );\
+      ++index_frame\
+    )
+
+#endif
+
+#define metil_audio_io_proc_macro_definition_index_channel\
+  unsigned long int index_channel = (\
+    index_frame %\
+    length_channels\
+  );  
+
+#define metil_audio_io_proc_macro_definition_frame_set(metil_audio_io_proc_macro_definition_value_frame)\
+  buffer_out[\
+    index_frame\
+  ] = (\
+    metil_audio_io_proc_macro_definition_value_frame\
+  );
+
+#define metil_audio_io_proc_macro_definition_return\
+  }\
+\
+  return (\
+    0x00\
+  );
+
 #endif

--- a/include/metil_audio/metil_audio_io_proc.h
+++ b/include/metil_audio/metil_audio_io_proc.h
@@ -32,4 +32,26 @@ void metil_audio_io_proc_destroy(
   struct metil_audio_data*
 );
 
+#if target_os_ios
+#define metil_audio_io_proc_macro_type(name_metil_audio_io_proc)\
+  int name_metil_audio_io_proc(\
+    unsigned char,\
+    const AudioTimeStamp* _Nonnull,\
+    unsigned int,\
+    AudioBufferList* _Nonnull,\
+    void* _Nonnull\
+  );
+#else
+#define metil_audio_io_proc_macro_type(name_metil_audio_io_proc)\
+  OSStatus name_metil_audio_io_proc(\
+    AudioObjectID,\
+    const AudioTimeStamp* _Nonnull,\
+    const AudioBufferList* _Nonnull,\
+    const AudioTimeStamp* _Nonnull,\
+    AudioBufferList* _Nonnull,\
+    const AudioTimeStamp* _Nonnull,\
+    void* _Nonnull\
+  );
+#endif
+
 #endif


### PR DESCRIPTION
- `metil_audio_io_proc`:add_macros
- - `metil_audio_io_proc_macro_type`
- - - type definitions for io proc functions
- - `metil_audio_io_proc_macro_definition`
- - - function definition for io proc functions
- - `metil_audio_io_proc_macro_definition_initializer`
- - - sets variables for `metil_io_proc_data` and `metil`
- - `metil_audio_io_proc_macro_definition_frame_loop`
- - - frame loops for buffer outputs
- - - - places at inner loop, requires 2 closing `}` (one if `metil_audio_io_proc_macro_definition_return` is used)
- - `metil_audio_io_proc_macro_definition_index_channel`
- - - sets `index_channel` variable
- - `metil_audio_io_proc_macro_definition_frame_set`
- - - sets the frame value for the output buffer
- - `metil_audio_io_proc_macro_definition_return`
- - - closes the `metil_audio_io_proc_macro_definition_frame_loop` outer for-loop and returns a status of `0x00`

these macros allow a "singular" function type and definition for both macos/ios without needing to place preprocessor directives

## example

### header.h

```c
#ifndef __some_header_h
#define __some_header_h

metil_audio_io_proc_macro_type(
  some_io_proc
);

#endif
```

### source.c

```c
#include <header.h>

#include <metil_audio/metil_audio_io_proc.h>

metil_audio_io_proc_macro_definition(
  some_io_proc
) {
  metil_audio_io_proc_macro_definition_initializer;

  // custom_initialization_code
    
  metil_audio_io_proc_macro_definition_frame_loop {
    metil_audio_io_proc_macro_definition_index_channel;

    float value_frame = (
      0x00
    );

    // some_code_using->{`index_channel`}.and_calculating->{`value_frame`};

    metil_audio_io_proc_macro_definition_frame_set(
      value_frame
    );
  }

  metil_audio_io_proc_macro_definition_return;
}
```