### PR TITLE
[dev] `examples/input`:metal_pipelines_with_indexing_refactor

### DIFF
--- a/examples/input/include/example_input_pipeline_index.h
+++ b/examples/input/include/example_input_pipeline_index.h
@@ -1,6 +1,18 @@
 #ifndef __examples_input_example_input_pipeline_index_h
 #define __examples_input_example_input_pipeline_index_h
 
-extern unsigned short int example_input_pipeline_index_model_item;
+struct example_input_pipeline_index {
+  unsigned short int model_player_body;
+  unsigned short int model_player_pants;
+  unsigned short int model_player_shirt;
 
+  unsigned short int model_skateboard_deck;
+  unsigned short int model_skateboard_truck;
+  unsigned short int model_skateboard_wheel;
+};
+
+
+void example_input_pipeline_index_initialize(
+  struct example_input_pipeline_index*
+);
 #endif

--- a/examples/input/metal/example_input_ground.metal
+++ b/examples/input/metal/example_input_ground.metal
@@ -4,11 +4,10 @@
 
 struct data_vertex {
   float4 position [[position]];
-  float point_size [[point_size]];
   float4 colour;
 };
 
-[[vertex]] struct data_vertex model_item_vertex(
+[[vertex]] struct data_vertex example_input_ground_vertex(
   const device simd_float4* vertices [[
     buffer(
       metil_renderer_vertex_index_parameter_vertices
@@ -45,11 +44,15 @@ struct data_vertex {
     data_object->colour.w
   );
 
-  return data_vertex;
+  return (
+    data_vertex
+  );
 }
 
-[[fragment]] float4 model_item_fragment(
+[[fragment]] float4 example_input_ground_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
-  return data_vertex.colour;
+  return (
+    data_vertex.colour
+  );
 }

--- a/examples/input/metal/example_input_model_player_body.metal
+++ b/examples/input/metal/example_input_model_player_body.metal
@@ -1,0 +1,73 @@
+#include <metil_joint/metil_joint_id_offset.h>
+#include <metil_metal/metil_metal_model_object.h>
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+#include <metil_rendering/metil_renderer_data_model_object.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 colour;
+};
+
+[[vertex]] struct data_vertex example_input_model_player_body_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_model_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  constant unsigned int* vertex_joint_map [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertex_joint_map
+    )
+  ]],
+  constant struct math_c_vector3_float* joints [[
+    buffer(
+      metil_renderer_vertex_index_parameter_joints
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  float4 position_vertex = (
+    metil_model_object_position_calculate(
+      id_vertex,
+      &vertices[
+        id_vertex
+      ],
+      &data_object->position,
+      vertex_joint_map,
+      joints
+    )
+  );
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    position_vertex
+  );
+
+  data_vertex.colour = float4(
+    1.0f,
+    1.0f,
+    1.0f,
+    1.0f
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 example_input_model_player_body_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return data_vertex.colour;
+}

--- a/examples/input/metal/example_input_model_player_pants.metal
+++ b/examples/input/metal/example_input_model_player_pants.metal
@@ -1,0 +1,73 @@
+#include <metil_joint/metil_joint_id_offset.h>
+#include <metil_metal/metil_metal_model_object.h>
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+#include <metil_rendering/metil_renderer_data_model_object.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 colour;
+};
+
+[[vertex]] struct data_vertex example_input_model_player_pants_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_model_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  constant unsigned int* vertex_joint_map [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertex_joint_map
+    )
+  ]],
+  constant struct math_c_vector3_float* joints [[
+    buffer(
+      metil_renderer_vertex_index_parameter_joints
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  float4 position_vertex = (
+    metil_model_object_position_calculate(
+      id_vertex,
+      &vertices[
+        id_vertex
+      ],
+      &data_object->position,
+      vertex_joint_map,
+      joints
+    )
+  );
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    position_vertex
+  );
+
+  data_vertex.colour = float4(
+    1.0f,
+    1.0f,
+    1.0f,
+    1.0f
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 example_input_model_player_pants_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return data_vertex.colour;
+}

--- a/examples/input/metal/example_input_model_player_shirt.metal
+++ b/examples/input/metal/example_input_model_player_shirt.metal
@@ -1,0 +1,73 @@
+#include <metil_joint/metil_joint_id_offset.h>
+#include <metil_metal/metil_metal_model_object.h>
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+#include <metil_rendering/metil_renderer_data_model_object.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 colour;
+};
+
+[[vertex]] struct data_vertex example_input_model_player_shirt_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_model_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  constant unsigned int* vertex_joint_map [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertex_joint_map
+    )
+  ]],
+  constant struct math_c_vector3_float* joints [[
+    buffer(
+      metil_renderer_vertex_index_parameter_joints
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  float4 position_vertex = (
+    metil_model_object_position_calculate(
+      id_vertex,
+      &vertices[
+        id_vertex
+      ],
+      &data_object->position,
+      vertex_joint_map,
+      joints
+    )
+  );
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    position_vertex
+  );
+
+  data_vertex.colour = float4(
+    1.0f,
+    1.0f,
+    1.0f,
+    1.0f
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 example_input_model_player_shirt_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return data_vertex.colour;
+}

--- a/examples/input/metal/example_input_model_skateboard_deck.metal
+++ b/examples/input/metal/example_input_model_skateboard_deck.metal
@@ -1,0 +1,73 @@
+#include <metil_joint/metil_joint_id_offset.h>
+#include <metil_metal/metil_metal_model_object.h>
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+#include <metil_rendering/metil_renderer_data_model_object.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 colour;
+};
+
+[[vertex]] struct data_vertex example_input_model_skateboard_deck_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_model_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  constant unsigned int* vertex_joint_map [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertex_joint_map
+    )
+  ]],
+  constant struct math_c_vector3_float* joints [[
+    buffer(
+      metil_renderer_vertex_index_parameter_joints
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  float4 position_vertex = (
+    metil_model_object_position_calculate(
+      id_vertex,
+      &vertices[
+        id_vertex
+      ],
+      &data_object->position,
+      vertex_joint_map,
+      joints
+    )
+  );
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    position_vertex
+  );
+
+  data_vertex.colour = float4(
+    1.0f,
+    1.0f,
+    1.0f,
+    1.0f
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 example_input_model_skateboard_deck_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return data_vertex.colour;
+}

--- a/examples/input/metal/example_input_model_skateboard_truck.metal
+++ b/examples/input/metal/example_input_model_skateboard_truck.metal
@@ -1,0 +1,73 @@
+#include <metil_joint/metil_joint_id_offset.h>
+#include <metil_metal/metil_metal_model_object.h>
+#include <metil_rendering/metil_renderer_data_frame.h>
+#include <metil_rendering/metil_renderer_vertex_index_parameter.h>
+#include <metil_rendering/metil_renderer_data_model_object.h>
+
+struct data_vertex {
+  float4 position [[position]];
+  float4 colour;
+};
+
+[[vertex]] struct data_vertex example_input_model_skateboard_truck_vertex(
+  const device simd_float4* vertices [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertices
+    )
+  ]],
+  constant struct metil_renderer_data_frame* data_frame [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_frame
+    )
+  ]],
+  constant struct metil_renderer_data_model_object* data_object [[
+    buffer(
+      metil_renderer_vertex_index_parameter_data_object
+    )
+  ]],
+  constant unsigned int* vertex_joint_map [[
+    buffer(
+      metil_renderer_vertex_index_parameter_vertex_joint_map
+    )
+  ]],
+  constant struct math_c_vector3_float* joints [[
+    buffer(
+      metil_renderer_vertex_index_parameter_joints
+    )
+  ]],
+  unsigned int id_vertex [[vertex_id]]
+) {
+  struct data_vertex data_vertex;
+
+  float4 position_vertex = (
+    metil_model_object_position_calculate(
+      id_vertex,
+      &vertices[
+        id_vertex
+      ],
+      &data_object->position,
+      vertex_joint_map,
+      joints
+    )
+  );
+
+  data_vertex.position = (
+    data_object->view_model_matrix_projection *
+    position_vertex
+  );
+
+  data_vertex.colour = float4(
+    1.0f,
+    1.0f,
+    1.0f,
+    1.0f
+  );
+
+  return data_vertex;
+}
+
+[[fragment]] float4 example_input_model_skateboard_truck_fragment(
+  struct data_vertex data_vertex [[stage_in]]
+) {
+  return data_vertex.colour;
+}

--- a/examples/input/metal/example_input_model_skateboard_wheel.metal
+++ b/examples/input/metal/example_input_model_skateboard_wheel.metal
@@ -9,7 +9,7 @@ struct data_vertex {
   float4 colour;
 };
 
-[[vertex]] struct data_vertex model_vertex(
+[[vertex]] struct data_vertex example_input_model_skateboard_wheel_vertex(
   const device simd_float4* vertices [[
     buffer(
       metil_renderer_vertex_index_parameter_vertices
@@ -66,7 +66,7 @@ struct data_vertex {
   return data_vertex;
 }
 
-[[fragment]] float4 model_fragment(
+[[fragment]] float4 example_input_model_skateboard_wheel_fragment(
   struct data_vertex data_vertex [[stage_in]]
 ) {
   return data_vertex.colour;

--- a/examples/input/sources/example_input.m
+++ b/examples/input/sources/example_input.m
@@ -3,6 +3,8 @@
 #include <example_input_pipeline_index.h>
 #include <example_input_scene.h>
 
+#include <clic3_memory.h>
+
 #include <metil.h>
 #include <metil_initialize.h>
 #include <metil_library.h>
@@ -24,22 +26,98 @@ void example_input_renderer_on_initialize(
   struct metil* metil,
   void* data
 ) {
+  metil->data = (
+    clic3_memory_allocate_raw(
+      sizeof(
+        struct example_input_pipeline_index
+      )
+    )
+  );
+
+  struct example_input_pipeline_index* example_input_pipeline_index = (
+    metil->data
+  );
+
+  example_input_pipeline_index_initialize(
+    example_input_pipeline_index
+  );
+
   metil_library_initialize(
     &metil->library,
     metil->renderer_interface.metal_device,
-    @"model_fragment",
-    @"model_vertex"
+    @"example_input_ground_fragment",
+    @"example_input_ground_vertex"
   );
 
-  example_input_pipeline_index_model_item = [
+  example_input_pipeline_index->model_player_body = [
     metil->renderer_interface.renderer
     pipeline_add: [
       metil->library.library
-      newFunctionWithName: @"model_item_fragment"
+      newFunctionWithName: @"example_input_model_player_body_fragment"
     ]
     function_vertex: [
       metil->library.library
-      newFunctionWithName: @"model_item_vertex"
+      newFunctionWithName: @"example_input_model_player_body_vertex"
+    ]
+  ];
+
+  example_input_pipeline_index->model_player_shirt = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_player_shirt_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_player_shirt_vertex"
+    ]
+  ];
+
+  example_input_pipeline_index->model_player_pants = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_player_pants_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_player_pants_vertex"
+    ]
+  ];
+
+  example_input_pipeline_index->model_skateboard_deck = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_skateboard_deck_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_skateboard_deck_vertex"
+    ]
+  ];
+
+  example_input_pipeline_index->model_skateboard_truck = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_skateboard_truck_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_skateboard_truck_vertex"
+    ]
+  ];
+
+  example_input_pipeline_index->model_skateboard_wheel = [
+    metil->renderer_interface.renderer
+    pipeline_add: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_skateboard_wheel_fragment"
+    ]
+    function_vertex: [
+      metil->library.library
+      newFunctionWithName: @"example_input_model_skateboard_wheel_vertex"
     ]
   ];
 

--- a/examples/input/sources/example_input_pipeline_index.c
+++ b/examples/input/sources/example_input_pipeline_index.c
@@ -1,5 +1,29 @@
 #include <example_input_pipeline_index.h>
 
-unsigned short int example_input_pipeline_index_model_item = (
-  0x00
-);
+void example_input_pipeline_index_initialize(
+  struct example_input_pipeline_index* example_input_pipeline_index
+) {
+  example_input_pipeline_index->model_player_body = (
+    0x00
+  );
+
+  example_input_pipeline_index->model_player_pants = (
+    0x00
+  );
+
+  example_input_pipeline_index->model_player_shirt = (
+    0x00
+  );
+
+  example_input_pipeline_index->model_skateboard_deck = (
+    0x00
+  );
+
+  example_input_pipeline_index->model_skateboard_truck = (
+    0x00
+  );
+
+  example_input_pipeline_index->model_skateboard_wheel = (
+    0x00
+  );
+}

--- a/examples/input/sources/example_input_scene.m
+++ b/examples/input/sources/example_input_scene.m
@@ -29,6 +29,10 @@ void example_input_scene_initialize(
   struct metil* metil,
   struct metil_scene* scene
 ) {
+  struct example_input_pipeline_index* example_input_pipeline_index = (
+    metil->data
+  );
+
   metil_scene_initialize_with_renderables(
     metil,
     scene,
@@ -1198,10 +1202,73 @@ void example_input_scene_initialize(
     1.0f
   );
 
-  metil_object_ground->index_pipeline_render = (
-    example_input_pipeline_index_model_item
+  metil_object_player_head->index_pipeline_render = (
+    example_input_pipeline_index->model_player_body
   );
 
+  metil_object_player_arm_left->index_pipeline_render = (
+    example_input_pipeline_index->model_player_shirt
+  );
+  
+  metil_object_player_arm_left_lower->index_pipeline_render = (
+    example_input_pipeline_index->model_player_body
+  );
+
+  metil_object_player_arm_right->index_pipeline_render = (
+    example_input_pipeline_index->model_player_shirt
+  );
+
+  metil_object_player_arm_right_lower->index_pipeline_render = (
+    example_input_pipeline_index->model_player_body
+  );
+
+  metil_object_player_body->index_pipeline_render = (
+    example_input_pipeline_index->model_player_shirt
+  );
+
+  metil_object_player_leg_left->index_pipeline_render = (
+    example_input_pipeline_index->model_player_pants
+  );
+
+  metil_object_player_leg_left_lower->index_pipeline_render = (
+    example_input_pipeline_index->model_player_pants
+  );
+
+  metil_object_player_leg_right->index_pipeline_render = (
+    example_input_pipeline_index->model_player_pants
+  );
+
+  metil_object_player_leg_right_lower->index_pipeline_render = (
+    example_input_pipeline_index->model_player_pants
+  );
+
+  metil_object_skateboard_deck->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_deck
+  );
+
+  metil_object_skateboard_truck_front->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_truck
+  );
+
+  metil_object_skateboard_wheel_front_left->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_wheel
+  );
+
+  metil_object_skateboard_wheel_front_right->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_wheel
+  );
+
+  metil_object_skateboard_truck_back->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_truck
+  );
+
+  metil_object_skateboard_wheel_back_left->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_wheel
+  );
+
+  metil_object_skateboard_wheel_back_right->index_pipeline_render = (
+    example_input_pipeline_index->model_skateboard_wheel
+  );
   scene->destroy = (
     example_input_scene_destroy
   );


### PR DESCRIPTION
- `examples/input`
- - initial->{`metal/*.metal`:files};
- - `example_input_pipeline_index`:refactor_to->{`struct`};
- - assign pipeline indices to each model object