### PR TITLE
[dev|enh] `metil_mesh_initialize_with_lengths`

### DIFF
--- a/include/metil_mesh/metil_mesh.h
+++ b/include/metil_mesh/metil_mesh.h
@@ -19,6 +19,12 @@ void metil_mesh_initialize(
   struct metil_mesh*
 );
 
+void metil_mesh_initialize_with_lengths(
+  struct metil_mesh*,
+  unsigned int,
+  unsigned int
+);
+
 void metil_mesh_clone(
   struct metil_mesh*,
   struct metil_mesh*

--- a/sources/metil_mesh/metil_mesh.c
+++ b/sources/metil_mesh/metil_mesh.c
@@ -2,31 +2,63 @@
 
 #include <clic3_memory.h>
 
+#include <math_c_vector.h>
+
 void metil_mesh_initialize(
   struct metil_mesh* metil_mesh
 ) {
-  metil_mesh->length_indices = 0;
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    0x00,
+    0x00
+  );
+}
 
-  metil_mesh->length_vertices = 0;
+void metil_mesh_initialize_with_lengths(
+  struct metil_mesh* metil_mesh,
+  unsigned int length_vertices,
+  unsigned int length_indices
+) {
+  metil_mesh->length_indices = (
+    length_indices
+  );
 
-  metil_mesh->size.x = 0.0f;
-  metil_mesh->size.y = 0.0f;
-  metil_mesh->size.z = 0.0f;
+  metil_mesh->length_vertices = (
+    length_vertices
+  );
+
+  metil_mesh->size.x = (
+    0x00
+  );
+
+  metil_mesh->size.y = (
+    0x00
+  );
+
+  metil_mesh->size.z = (
+    0x00
+  );
 
   metil_mesh->indices = (
     clic3_memory_allocate_raw(
-      0
+      sizeof(
+        unsigned int
+      ) *
+      metil_mesh->length_indices
     )
   );
 
   metil_mesh->vertices = (
     clic3_memory_allocate_raw(
-      0
+      sizeof(
+        struct math_c_vector4_float
+      ) *
+      metil_mesh->length_vertices
     )
   );
 
   metil_mesh->data = (
-    0
+    0x00
   );
 }
 
@@ -34,12 +66,10 @@ void metil_mesh_clone(
   struct metil_mesh* mesh_source,
   struct metil_mesh* mesh_clone
 ) {
-  mesh_clone->indices = 0;
   mesh_clone->length_indices = (
     mesh_source->length_indices
   );
 
-  mesh_clone->vertices = 0;
   mesh_clone->length_vertices = (
     mesh_source->length_vertices
   );
@@ -75,8 +105,13 @@ void metil_mesh_clone(
   );
 
   for (
-    unsigned int index_index = 0;
-    index_index < mesh_clone->length_indices;
+    unsigned int index_index = (
+      0x00
+    );
+    (
+      index_index <
+      mesh_clone->length_indices
+    );
     ++index_index
   ) {
     mesh_clone->indices[
@@ -89,8 +124,13 @@ void metil_mesh_clone(
   }
 
   for (
-    unsigned int index_vertex = 0;
-    index_vertex < mesh_clone->length_vertices;
+    unsigned int index_vertex = (
+      0x00
+    );
+    (
+      index_vertex <
+      mesh_clone->length_vertices
+    );
     ++index_vertex
   ) {
     mesh_clone->vertices[
@@ -126,7 +166,9 @@ void metil_mesh_clone(
     );
   }
 
-  mesh_clone->data = 0;
+  mesh_clone->data = (
+    0x00
+  );
 }
 
 void metil_mesh_destroy(

--- a/sources/metil_mesh/metil_mesh_2d/metil_mesh_circle.c
+++ b/sources/metil_mesh/metil_mesh_2d/metil_mesh_circle.c
@@ -12,8 +12,16 @@ void metil_mesh_circle_initialize(
   float diameter,
   unsigned short int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments +
+      0x01
+    ),
+    (
+      segments *
+      0x03
+    )
   );
 
   float radius = (
@@ -21,33 +29,17 @@ void metil_mesh_circle_initialize(
     2.0f
   );
 
-  metil_mesh->size.x = diameter;
-  metil_mesh->size.y = diameter;
-  metil_mesh->size.z = diameter;
-
-  metil_mesh->length_vertices = segments + 1;
-  metil_mesh->length_indices = segments * 3;
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
+  metil_mesh->size.x = (
+    diameter
   );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
+  
+  metil_mesh->size.y = (
+    diameter
   );
-
+  
+  metil_mesh->size.z = (
+    diameter
+  );
   metil_mesh->vertices[0].x = 0.0f;
   metil_mesh->vertices[0].y = 0.0f;
   metil_mesh->vertices[0].z = 0.0f;

--- a/sources/metil_mesh/metil_mesh_2d/metil_mesh_grid.c
+++ b/sources/metil_mesh/metil_mesh_2d/metil_mesh_grid.c
@@ -11,38 +11,24 @@ void metil_mesh_celled_grid_initialize(
   struct math_c_vector2_float size,
   struct math_c_vector2_unsigned_long_int cells
 ) {
-  metil_mesh_initialize(
-    metil_mesh
-  );
-
-  metil_mesh->size.x = (
-    size.x
-  );
-  metil_mesh->size.y = (
-    size.y
-  );
-  metil_mesh->size.z = (
-    0.0f
-  );
-
   struct math_c_vector2_float size_cell = {
     .x = (
-      metil_mesh->size.x /
+      size.x /
       cells.x
     ),
     .y = (
-      metil_mesh->size.y /
+      size.y /
       cells.y
     )
   };
 
   struct math_c_vector2_float size_half = {
     .x = (
-      metil_mesh->size.x /
+      size.x /
       2.0f
     ),
     .y = (
-      metil_mesh->size.y /
+      size.y /
       2.0f
     )
   };
@@ -52,52 +38,46 @@ void metil_mesh_celled_grid_initialize(
     cells.y
   );
 
-  metil_mesh->length_vertices = (
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
     (
-      cells.x +
-      1
-    ) *
-    (
-      cells.y +
-      1
-    )
-  );
-
-  metil_mesh->length_indices = (
-    total_cells *
-    4 +
-    cells.y *
-    2 +
-    cells.x *
-    2
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
+      (
+        cells.x +
+        0x01
       ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
+      (
+        cells.y +
+        0x01
+      )
+    ),
     (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
+      total_cells *
+      0x04 +
+      cells.y *
+      0x02 +
+      cells.x *
+      0x02
     )
   );
 
+  metil_mesh->size.x = (
+    size.x
+  );
+
+  metil_mesh->size.y = (
+    size.y
+  );
+
+  metil_mesh->size.z = (
+    0x00
+  );
+  
   unsigned long int index_index = (
-    0
+    0x00
   );
 
   unsigned long int index_vertex = (
-    0
+    0x00
   );
 
   for (
@@ -282,85 +262,64 @@ void metil_mesh_celled_triangles_grid_initialize(
   struct math_c_vector2_float size,
   struct math_c_vector2_unsigned_long_int cells
 ) {
-  metil_mesh_initialize(
-    metil_mesh
-  );
-
-  metil_mesh->size.x = (
-    size.x
-  );
-  metil_mesh->size.y = (
-    size.y
-  );
-  metil_mesh->size.z = (
-    0.0f
-  );
-
   struct math_c_vector2_float size_cell = {
     .x = (
-      metil_mesh->size.x /
+      size.x /
       cells.x
     ),
     .y = (
-      metil_mesh->size.y /
+      size.y /
       cells.y
     )
   };
 
   struct math_c_vector2_float size_half = {
     .x = (
-      metil_mesh->size.x /
+      size.x /
       2.0f
     ),
     .y = (
-      metil_mesh->size.y /
+      size.y /
       2.0f
     )
   };
 
-  metil_mesh->length_vertices = (
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
     (
-      cells.x +
-      1
-    ) *
-    (
-      cells.y +
-      1
-    )
-  );
-
-  metil_mesh->length_indices = (
-    cells.x *
-    cells.y *
-    6
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
+      (
+        cells.x +
+        0x01
       ) *
-      metil_mesh->length_indices
+      (
+        cells.y +
+        0x01
+      )
+    ),
+    (      cells.x *
+      cells.y *
+      0x06
     )
   );
 
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
+  metil_mesh->size.x = (
+    size.x
+  );
+
+  metil_mesh->size.y = (
+    size.y
+  );
+
+  metil_mesh->size.z = (
+    0x00
   );
 
   unsigned long int index_index = (
-    0
+    0x00
   );
 
   unsigned long int index_vertex = (
-    0
+    0x00
   );
 
   for (
@@ -475,28 +434,14 @@ void metil_mesh_celled_triangles_quadruple_grid_initialize(
   struct math_c_vector2_float size,
   struct math_c_vector2_unsigned_long_int cells
 ) {
-  metil_mesh_initialize(
-    metil_mesh
-  );
-
-  metil_mesh->size.x = (
-    size.x
-  );
-  metil_mesh->size.y = (
-    size.y
-  );
-  metil_mesh->size.z = (
-    0.0f
-  );
-
   struct math_c_vector2_float size_cell = {
     .x = (
-      metil_mesh->size.x /
+      size.x /
       (float)
       cells.x
     ),
     .y = (
-      metil_mesh->size.y /
+      size.y /
       (float)
       cells.y
     )
@@ -504,73 +449,66 @@ void metil_mesh_celled_triangles_quadruple_grid_initialize(
 
   struct math_c_vector2_float size_half = {
     .x = (
-      metil_mesh->size.x /
-      2.0f
+      size.x /
+      0x02
     ),
     .y = (
-      metil_mesh->size.y /
-      2.0f
+      size.y /
+      0x02
     )
   };
 
   struct math_c_vector2_float size_cell_half = {
     .x = (
       size_cell.x /
-      2.0f
+      0x02
     ),
     .y = (
       size_cell.y /
-      2.0f
+      0x02
     )
   };
 
-  metil_mesh->length_vertices = (
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
     (
-      cells.x +
-      1
-    ) *
-    (
-      cells.y +
-      1
-    ) +
-    (
-      cells.x *
-      cells.y
-    )
-  );
-
-  metil_mesh->length_indices = (
-    cells.x *
-    cells.y *
-    12
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
+      (
+        cells.x +
+        0x01
       ) *
-      metil_mesh->length_indices
+      (
+        cells.y +
+        0x01
+      ) +
+      (
+        cells.x *
+        cells.y
+      )
+    ),
+    (      cells.x *
+      cells.y *
+      0x0c
     )
   );
 
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+
+  metil_mesh->size.z = (
+    0x00
   );
 
   unsigned long int index_index = (
-    0
+    0x00
   );
 
   unsigned long int index_vertex = (
-    0
+    0x00
   );
 
   for (
@@ -853,39 +791,25 @@ void metil_mesh_celled_individual_triangles_grid_initialize(
   struct math_c_vector2_float size,
   struct math_c_vector2_unsigned_long_int cells
 ) {
-  metil_mesh_initialize(
-    metil_mesh
-  );
-
-  metil_mesh->size.x = (
-    size.x
-  );
-  metil_mesh->size.y = (
-    size.y
-  );
-  metil_mesh->size.z = (
-    0.0f
-  );
-
   struct math_c_vector2_float size_cell = {
     .x = (
-      metil_mesh->size.x /
+      size.x /
       cells.x
     ),
     .y = (
-      metil_mesh->size.y /
+      size.y /
       cells.y
     )
   };
 
   struct math_c_vector2_float size_half = {
     .x = (
-      metil_mesh->size.x /
-      2.0f
+      size.x /
+      0x02
     ),
     .y = (
-      metil_mesh->size.y /
-      2.0f
+      size.y /
+      0x02
     )
   };
 
@@ -894,14 +818,15 @@ void metil_mesh_celled_individual_triangles_grid_initialize(
     cells.y
   );
 
-  metil_mesh->length_vertices = (
-    total_cells *
-    4
-  );
-
-  metil_mesh->length_indices = (
-    total_cells *
-    6
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      total_cells *
+      0x04
+    ),
+    (      total_cells *
+      0x06
+    )
   );
 
   clic3_memory_reallocate_raw(
@@ -911,16 +836,6 @@ void metil_mesh_celled_individual_triangles_grid_initialize(
         unsigned int
       ) *
       metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
     )
   );
 

--- a/sources/metil_mesh/metil_mesh_2d/metil_mesh_rectangle.c
+++ b/sources/metil_mesh/metil_mesh_2d/metil_mesh_rectangle.c
@@ -10,41 +10,34 @@ void metil_mesh_rectangle_initialize(
   struct metil_mesh* metil_mesh,
   struct math_c_vector2_float size
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    0x04,
+    0x06
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = 0.0f;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    0x00
+  );
 
   struct math_c_vector2_float size_half = {
-    .x = metil_mesh->size.x / 2.0f,
-    .y = metil_mesh->size.y / 2.0f
+    .x = (
+      metil_mesh->size.x /
+      0x02
+    ),
+    .y = (
+      metil_mesh->size.y /
+      0x02
+    )
   };
-
-  metil_mesh->length_vertices = 4;
-  metil_mesh->length_indices = 6;
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = -size_half.x;
   metil_mesh->vertices[0].y = -size_half.y;

--- a/sources/metil_mesh/metil_mesh_2d/metil_mesh_square.c
+++ b/sources/metil_mesh/metil_mesh_2d/metil_mesh_square.c
@@ -8,37 +8,27 @@ void metil_mesh_square_initialize(
   struct metil_mesh* metil_mesh,
   float size
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    0x04,
+    0x06
   );
 
-  metil_mesh->size.x = size;
-  metil_mesh->size.y = size;
-  metil_mesh->size.z = 0.0f;
-
-  float size_half = size / 2.0f;
-
-  metil_mesh->length_vertices = 4;
-  metil_mesh->length_indices = 6;
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
+  metil_mesh->size.x = (
+    size
+  );
+  
+  metil_mesh->size.y = (
+    size
+  );
+  
+  metil_mesh->size.z = (
+    0x00
   );
 
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
+  float size_half = (
+    size /
+    0x02
   );
 
   metil_mesh->vertices[0].x = -size_half;

--- a/sources/metil_mesh/metil_mesh_2d/metil_mesh_triangle.c
+++ b/sources/metil_mesh/metil_mesh_2d/metil_mesh_triangle.c
@@ -10,41 +10,34 @@ void metil_mesh_triangle_initialize(
   struct metil_mesh* metil_mesh,
   struct math_c_vector2_float size
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    0x03,
+    0x03
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = 0.0f;
+  metil_mesh->size.x = (
+    size.x
+  );
+
+  metil_mesh->size.y = (
+    size.y
+  );
+
+  metil_mesh->size.z = (
+    0x00
+  );
 
   struct math_c_vector2_float size_half = {
-    .x = metil_mesh->size.x / 2.0f,
-    .y = metil_mesh->size.y / 2.0f
+    .x = (
+      metil_mesh->size.x /
+      0x02
+    ),
+    .y = (
+      metil_mesh->size.y /
+      0x02
+    )
   };
-
-  metil_mesh->length_vertices = 3;
-  metil_mesh->length_indices = 3;
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = -size_half.x;
   metil_mesh->vertices[0].y = -size_half.y;

--- a/sources/metil_mesh/metil_mesh_ball.c
+++ b/sources/metil_mesh/metil_mesh_ball.c
@@ -13,8 +13,25 @@ void metil_mesh_ball_initialize(
   float diameter,
   struct math_c_vector2_unsigned_short_int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments.x *
+      segments.y +
+      0x02
+    ),
+    (
+      0x06 *
+      segments.x +
+      (
+        segments.x *
+        (
+          segments.y -
+          0x01
+        ) *
+        0x06
+      )
+    )
   );
 
   metil_mesh->size.x = (
@@ -32,44 +49,6 @@ void metil_mesh_ball_initialize(
   float radius = (
     diameter /
     2.0f
-  );
-
-  metil_mesh->length_vertices = (
-    segments.x *
-    segments.y +
-    2
-  );
-
-  metil_mesh->length_indices = (
-    6 * (
-      segments.x
-    ) + (
-      segments.x * (
-        segments.y -
-        1
-      ) *
-      6
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
   );
 
   metil_mesh->vertices[0].x = 0.0f;

--- a/sources/metil_mesh/metil_mesh_box.c
+++ b/sources/metil_mesh/metil_mesh_box.c
@@ -8,42 +8,38 @@ void metil_mesh_box_initialize(
   struct metil_mesh* metil_mesh,
   struct math_c_vector3_float size
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    0x08,
+    0x24
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = size.z;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    size.z
+  );
 
   struct math_c_vector3_float size_half = {
-    .x = metil_mesh->size.x / 2.0f,
-    .y = metil_mesh->size.y / 2.0f,
-    .z = metil_mesh->size.z / 2.0f
+    .x = (
+      metil_mesh->size.x /
+      0x02
+    ),
+    .y = (
+      metil_mesh->size.y /
+      0x02
+    ),
+    .z = (
+      metil_mesh->size.z /
+      0x02
+    )
   };
-
-  metil_mesh->length_vertices = 8;
-  metil_mesh->length_indices = 36;
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = -size_half.x;
   metil_mesh->vertices[0].y = -size_half.y;

--- a/sources/metil_mesh/metil_mesh_dollop.c
+++ b/sources/metil_mesh/metil_mesh_dollop.c
@@ -13,66 +13,53 @@ void metil_mesh_dollop_initialize(
   struct math_c_vector3_float size,
   struct math_c_vector2_unsigned_short_int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments.x *
+      segments.y +
+      0x02
+    ),
+    (
+      0x06 *
+      segments.x +
+      (
+        segments.x *
+        (
+          segments.y -
+          0x01
+        ) *
+        0x06
+      )
+    )
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = size.z;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    size.z
+  );
 
   struct math_c_vector3_float size_half = {
     .x = (
       size.x /
-      2.0f
+      0x02
     ),
     .y = (
       size.y /
-      2.0f
+      0x02
     ),
     .z = (
       size.z /
-      2.0f
+      0x02
     )
   };
-
-  metil_mesh->length_vertices = (
-    segments.x *
-    segments.y +
-    2
-  );
-
-  metil_mesh->length_indices = (
-    6 * (
-      segments.x
-    ) + (
-      segments.x * (
-        segments.y -
-        1
-      ) *
-      6
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = 0.0f;
   metil_mesh->vertices[0].y = -size_half.y;

--- a/sources/metil_mesh/metil_mesh_gem.c
+++ b/sources/metil_mesh/metil_mesh_gem.c
@@ -13,66 +13,53 @@ void metil_mesh_gem_initialize(
   struct math_c_vector3_float size,
   struct math_c_vector2_unsigned_short_int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments.x *
+      segments.y +
+      0x02
+    ),
+    (
+      0x06 *
+      segments.x +
+      (
+        segments.x *
+        (
+          segments.y -
+          0x01
+        ) *
+        0x06
+      )
+    )
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = size.z;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    size.z
+  );
 
   struct math_c_vector3_float size_half = {
     .x = (
       size.x /
-      2.0f
+      0x02
     ),
     .y = (
       size.y /
-      2.0f
+      0x02
     ),
     .z = (
       size.z /
-      2.0f
+      0x02
     )
   };
-
-  metil_mesh->length_vertices = (
-    segments.x *
-    segments.y +
-    2
-  );
-
-  metil_mesh->length_indices = (
-    6 * (
-      segments.x
-    ) + (
-      segments.x * (
-        segments.y -
-        1
-      ) *
-      6
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = 0.0f;
   metil_mesh->vertices[0].y = -size_half.y;

--- a/sources/metil_mesh/metil_mesh_line.c
+++ b/sources/metil_mesh/metil_mesh_line.c
@@ -11,43 +11,21 @@ void metil_mesh_line_initialize(
   unsigned int length_points,
   struct math_c_vector3_float* points
 ) {
-  metil_mesh_initialize(
-    metil_mesh_line
-  );
-
-  metil_mesh_line->length_indices = (
+  metil_mesh_initialize_with_lengths(
+    metil_mesh_line,
+    length_points,
     (
-      length_points -
-      1
-    ) *
-    2
-  );
-
-  metil_mesh_line->length_vertices = (
-    length_points
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh_line->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh_line->length_indices
+      0x02 *
+      (
+        length_points -
+        0x01
+      )
     )
   );
 
-  clic3_memory_reallocate_raw(
-    &metil_mesh_line->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh_line->length_vertices
-    )
+  unsigned int index_index = (
+    0x00
   );
-
-  unsigned int index_index = 0;
 
   struct math_c_vector3_float size_minimums = {
     .x = (

--- a/sources/metil_mesh/metil_mesh_mushroom.c
+++ b/sources/metil_mesh/metil_mesh_mushroom.c
@@ -13,66 +13,51 @@ void metil_mesh_mushroom_initialize(
   struct math_c_vector3_float size,
   struct math_c_vector2_unsigned_short_int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments.x *
+      segments.y +
+      0x02
+    ),
+    (
+      0x06 *
+      segments.x +
+      segments.x *
+      (
+        segments.y -
+        0x01
+      ) *
+      0x06
+    )
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = size.z;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    size.z
+  );
 
   struct math_c_vector3_float size_half = {
     .x = (
       size.x /
-      2.0f
+      0x02
     ),
     .y = (
       size.y /
-      2.0f
+      0x02
     ),
     .z = (
       size.z /
-      2.0f
+      0x02
     )
   };
-
-  metil_mesh->length_vertices = (
-    segments.x *
-    segments.y +
-    2
-  );
-
-  metil_mesh->length_indices = (
-    6 * (
-      segments.x
-    ) + (
-      segments.x * (
-        segments.y -
-        1
-      ) *
-      6
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = 0.0f;
   metil_mesh->vertices[0].y = size_half.y;

--- a/sources/metil_mesh/metil_mesh_parse.c
+++ b/sources/metil_mesh/metil_mesh_parse.c
@@ -3,13 +3,6 @@
 #include <metil_mesh/metil_mesh.h>
 #include <metil_status.h>
 
-// struct math_c_vector3_float size;
-
-// unsigned int* indices;
-// struct math_c_vector4_float* vertices;
-
-// void* data;
-
 metil_status metil_mesh_parse(
   struct metil_mesh* metil_mesh,
   char* mesh_import

--- a/sources/metil_mesh/metil_mesh_ring.c
+++ b/sources/metil_mesh/metil_mesh_ring.c
@@ -12,12 +12,22 @@ void metil_mesh_ring_initialize(
   struct math_c_vector3_float size_inner,
   struct math_c_vector2_unsigned_short_int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh_ring
+  metil_mesh_initialize_with_lengths(
+    metil_mesh_ring,
+    (
+      segments.x *
+      segments.y
+    ),
+    (
+      segments.x *
+      segments.y *
+      0x06
+    )
   );
 
   if (
-    size_outer.x < size_inner.x
+    size_outer.x <
+    size_inner.x
   ) {
     float size_x_hold = (
       size_outer.x
@@ -33,7 +43,8 @@ void metil_mesh_ring_initialize(
   }
 
   if (
-    size_outer.z < size_inner.z
+    size_outer.z <
+    size_inner.z
   ) {
     float size_z_hold = (
       size_outer.z
@@ -129,38 +140,13 @@ void metil_mesh_ring_initialize(
     ),
   };
 
-  metil_mesh_ring->length_vertices = (
-    segments.x *
-    segments.y
+  unsigned int index_vertex = (
+    0x00
   );
-
-  metil_mesh_ring->length_indices = (
-    metil_mesh_ring->length_vertices *
-    6
+  
+  unsigned int index_index = (
+    0x00
   );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh_ring->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh_ring->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh_ring->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh_ring->length_vertices
-    )
-  );
-
-  unsigned int index_vertex = 0;
-  unsigned int index_index = 0;
 
   for (
     unsigned short int index_segment_x = 0;

--- a/sources/metil_mesh/metil_mesh_shuttle.c
+++ b/sources/metil_mesh/metil_mesh_shuttle.c
@@ -13,66 +13,51 @@ void metil_mesh_shuttle_initialize(
   struct math_c_vector3_float size,
   struct math_c_vector2_unsigned_short_int segments
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments.x *
+      segments.y +
+      0x02
+    ),
+    (
+      0x06 *
+      segments.x +
+      segments.x *
+      (
+        segments.y -
+        0x01
+      ) *
+      0x06
+    )  
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = size.z;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    size.z
+  );
 
   struct math_c_vector3_float size_half = {
     .x = (
       size.x /
-      2.0f
+      0x02
     ),
     .y = (
       size.y /
-      2.0f
+      0x02
     ),
     .z = (
       size.z /
-      2.0f
+      0x02
     )
   };
-
-  metil_mesh->length_vertices = (
-    segments.x *
-    segments.y +
-    2
-  );
-
-  metil_mesh->length_indices = (
-    6 * (
-      segments.x
-    ) + (
-      segments.x * (
-        segments.y -
-        1
-      ) *
-      6
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   metil_mesh->vertices[0].x = 0.0f;
   metil_mesh->vertices[0].y = size_half.y;

--- a/sources/metil_mesh/metil_mesh_text.c
+++ b/sources/metil_mesh/metil_mesh_text.c
@@ -12,8 +12,10 @@ void metil_mesh_text_initialize(
   float height,
   float scale
 ) {
-  metil_mesh_initialize(
-    mesh
+  metil_mesh_initialize_with_lengths(
+    mesh,
+    0x04,
+    0x06
   );
 
   mesh->size.x = (
@@ -26,49 +28,19 @@ void metil_mesh_text_initialize(
     scale
   );
 
-  mesh->size.z = 1.0f;
-
-  mesh->length_vertices = (
-    4
-  );
-
-  mesh->length_indices = (
-    6
-  );
-
-  clic3_memory_reallocate_raw(
-    &mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      mesh->length_vertices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      mesh->length_indices
-    )
+  mesh->size.z = (
+    0x01
   );
 
   float width_half = (
-    (
-      width /
-      2.0f
-    ) *
+    width /
+    0x02 *
     scale
   );
 
   float height_half = (
-    (
-      height /
-      2.0f
-    ) *
+    height /
+    0x02 *
     scale
   );
 

--- a/sources/metil_mesh/metil_mesh_tube.c
+++ b/sources/metil_mesh/metil_mesh_tube.c
@@ -15,66 +15,51 @@ void metil_mesh_tube_initialize(
   struct math_c_vector2_unsigned_short_int segments,
   enum metil_direction direction
 ) {
-  metil_mesh_initialize(
-    metil_mesh
+  metil_mesh_initialize_with_lengths(
+    metil_mesh,
+    (
+      segments.x *
+      segments.y +
+      0x02
+    ),
+    (
+      0x06 *
+      segments.x +
+      segments.x *
+      (
+        segments.y -
+        0x01
+      ) *
+      0x06
+    )
   );
 
-  metil_mesh->size.x = size.x;
-  metil_mesh->size.y = size.y;
-  metil_mesh->size.z = size.z;
+  metil_mesh->size.x = (
+    size.x
+  );
+  
+  metil_mesh->size.y = (
+    size.y
+  );
+  
+  metil_mesh->size.z = (
+    size.z
+  );
 
   struct math_c_vector3_float size_half = {
     .x = (
       size.x /
-      2.0f
+      0x02
     ),
     .y = (
       size.y /
-      2.0f
+      0x02
     ),
     .z = (
       size.z /
-      2.0f
+      0x02
     )
   };
-
-  metil_mesh->length_vertices = (
-    segments.x *
-    segments.y +
-    2
-  );
-
-  metil_mesh->length_indices = (
-    6 * (
-      segments.x
-    ) + (
-      segments.x * (
-        segments.y -
-        1
-      ) *
-      6
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->indices,
-    (
-      sizeof(
-        unsigned int
-      ) *
-      metil_mesh->length_indices
-    )
-  );
-
-  clic3_memory_reallocate_raw(
-    &metil_mesh->vertices,
-    (
-      sizeof(
-        struct math_c_vector4_float
-      ) *
-      metil_mesh->length_vertices
-    )
-  );
 
   unsigned int index_index = (
     0


### PR DESCRIPTION
- `metil_mesh_initialize_with_lengths`
- - initialization of `metil_mesh` with vertices and indices lengths
- - prevents needing to reallocate vertices and indices
- - - speeds up initialization slightly
- `metil_mesh_*`:use->{`metil_mesh_initialize_with_lengths`};