### PR TITLE
[enh] `metil_metal_data_vertex`:add->{`brightness`};

### DIFF
--- a/include/metil_metal/metil_metal_data_vertex.h
+++ b/include/metil_metal/metil_metal_data_vertex.h
@@ -8,18 +8,21 @@ struct data_vertex_basic {
 struct data_vertex_basic_coloured {
   float4 position [[position]];
   float4 colour;
+  float brightness;
 };
 
 struct data_vertex_basic_textured_coloured {
   float4 position [[position]];
   float2 position_texture;
   float4 colour;
+  float brightness;
 };
 
 struct data_vertex_basic_multiple_textured_coloured {
   float4 position [[position]];
   float2 position_texture;
   float4 colour;
+  float brightness;
   unsigned char index_texture;
 };
 


### PR DESCRIPTION
- `metil_metal_data_vertex`:add->{`brightness`};
- - single brightness value instead of one for general brightness and one for text brightness since typically the fragment shader only needs one of the two