### PR TITLE
[dev] Text refactors

### DIFF
--- a/sources/metil_text/metil_text.m
+++ b/sources/metil_text/metil_text.m
@@ -590,8 +590,4 @@ void metil_text_destroy(
   metil_text_render_parameters_destroy(
     metil_text_render_parameters
   );
-
-  CFRelease(
-    metil_text_render_parameters->font
-  );
 }

--- a/sources/metil_text/metil_text_render_parameters.m
+++ b/sources/metil_text/metil_text_render_parameters.m
@@ -1,29 +1,36 @@
 #include <metil_text/metil_text_render_parameters.h>
 
 #include <CoreText/CTFont.h>
+#include <Foundation/NSObject.h>
+#include <Foundation/NSString.h>
 
 void metil_text_render_parameters_initialize(
   struct metil_text_render_parameters* metil_text_render_parameters,
   char* name_family_font,
   float size
 ) {
-  CFStringRef name_family_font_core_foundation_string = (
-    __CFStringMakeConstantString(
+  NSString* string_name_family_font = [
+    [
+      NSString
+      alloc
+    ]
+    initWithUTF8String: (
       name_family_font
     )
-  );
+  ];
 
   metil_text_render_parameters->font = (
     CTFontCreateWithName(
-      name_family_font_core_foundation_string,
+      string_name_family_font,
       size,
       0x00
     )
   );
-
-  CFRelease(
-    name_family_font_core_foundation_string
-  );
+  
+  [
+    string_name_family_font
+    release
+  ];
 }
 
 void metil_text_render_parameters_destroy(


### PR DESCRIPTION
- `metil_text`
- - remove double release of font
- `metil_text_render_parameters`
- - use `NSString`

removing all corefoundation references would be nice

corefoundation is too red.