### PR TITLE
[enh] `metil_rendering_properties_mode_wireframe_full`

### DIFF
--- a/include/metil_rendering/metil_renderable_type.h
+++ b/include/metil_rendering/metil_renderable_type.h
@@ -2,10 +2,10 @@
 #define __metil_rendering_metil_renderable_type_h
 
 enum metil_renderable_type {
-  metil_renderable_type_group = 0,
-  metil_renderable_type_object = 1,
-  metil_renderable_type_menu = 2,
-  metil_renderable_type_model = 3
+  metil_renderable_type_group  = 0x00,
+  metil_renderable_type_object = 0x01,
+  metil_renderable_type_menu   = 0x02,
+  metil_renderable_type_model  = 0x03
 };
 
 #endif

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -30,7 +30,7 @@
 
 @interface metil_renderer : NSObject<MTKViewDelegate> {
   struct metil* metil;
-  
+
   MTKView* view;
 
   id<MTLCommandQueue> command_queue;
@@ -65,7 +65,7 @@
   matrix_float3x4 matrix_projection_static;
 
   @public metil_renderer_data_frame_poll_function poll_data_frame;
- 
+
   unsigned char destroying;
   pthread_mutex_t mutex_destroying;
 }

--- a/include/metil_rendering/metil_rendering_properties.h
+++ b/include/metil_rendering/metil_rendering_properties.h
@@ -8,19 +8,20 @@
 
 #include <pthread.h>
 
-#define metil_count_max_frames 1
+#define metil_count_max_frames 0x01
 
-#define metil_count_time_frames 60
+#define metil_count_time_frames 0x3c
 
 enum metil_rendering_properties_mode {
-  metil_rendering_properties_mode_default   = 0b01,
-  metil_rendering_properties_mode_wireframe = 0b10
+  metil_rendering_properties_mode_default        = 0b0001,
+  metil_rendering_properties_mode_wireframe      = 0b0010,
+  metil_rendering_properties_mode_wireframe_full = 0b0100
 };
 
 enum metil_rendering_properties_disables {
-  metil_rendering_properties_disables_none      = 0b00,
-  metil_rendering_properties_disables_polling   = 0b01,
-  metil_rendering_properties_disables_rendering = 0b10
+  metil_rendering_properties_disables_none      = 0b0000,
+  metil_rendering_properties_disables_polling   = 0b0001,
+  metil_rendering_properties_disables_rendering = 0b0010
 };
 
 struct metil_rendering_properties {

--- a/sources/metil.m
+++ b/sources/metil.m
@@ -47,15 +47,15 @@ void metil_destroy(
   struct metil* metil = (
     metil_pointer
   );
-  
+
   metil->renderer_interface.renderer->destroying = (
     0x01
   );
-  
+
   pthread_mutex_lock(
     &metil->renderer_interface.renderer->mutex_destroying
   );
-  
+
   pthread_mutex_unlock(
     &metil->renderer_interface.renderer->mutex_destroying
   );

--- a/sources/metil_rendering/metil_camera/metil_camera.c
+++ b/sources/metil_rendering/metil_camera/metil_camera.c
@@ -14,7 +14,7 @@ void metil_camera_initialize(
   metil_camera->field_of_view.x = (
     1.45f
   );
-  
+
   metil_camera->field_of_view.y = (
     metil_camera->field_of_view.x *
     (
@@ -43,7 +43,7 @@ void metil_camera_initialize(
   metil_camera->distance_view.near = (
     0.5f
   );
-  
+
   metil_camera->distance_view.far = (
     10000.0f
   );

--- a/sources/metil_rendering/metil_descriptors/metil_pipeline_render.m
+++ b/sources/metil_rendering/metil_descriptors/metil_pipeline_render.m
@@ -18,7 +18,7 @@ void metil_rendering_descriptors_pipeline_render_initialize(
   descriptor_pipeline_render.fragmentFunction = (
     function_fragment
   );
-  
+
   descriptor_pipeline_render.vertexFunction = (
     function_vertex
   );
@@ -34,37 +34,37 @@ void metil_rendering_descriptors_pipeline_render_initialize(
   ].blendingEnabled = (
     0x01
   );
-  
+
   descriptor_pipeline_render.colorAttachments[
     0x00
   ].rgbBlendOperation = (
     MTLBlendOperationAdd
   );
-  
+
   descriptor_pipeline_render.colorAttachments[
     0x00
   ].alphaBlendOperation = (
     MTLBlendOperationAdd
   );
-  
+
   descriptor_pipeline_render.colorAttachments[
     0x00
   ].sourceRGBBlendFactor = (
     MTLBlendFactorSourceAlpha
   );
-  
+
   descriptor_pipeline_render.colorAttachments[
     0x00
   ].sourceAlphaBlendFactor = (
     MTLBlendFactorSourceAlpha
   );
-  
+
   descriptor_pipeline_render.colorAttachments[
     0x00
   ].destinationRGBBlendFactor = (
     MTLBlendFactorOneMinusSourceAlpha
   );
-  
+
   descriptor_pipeline_render.colorAttachments[
     0x00
   ].destinationAlphaBlendFactor = (
@@ -74,7 +74,7 @@ void metil_rendering_descriptors_pipeline_render_initialize(
   descriptor_pipeline_render.depthAttachmentPixelFormat = (
     format_pixel_depth
   );
-  
+
   descriptor_pipeline_render.stencilAttachmentPixelFormat = (
     format_pixel_stencil
   );

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -201,16 +201,16 @@
     self
     pipelines_initialize
   ];
-  
+
   self->destroying = (
     0x00
   );
-  
+
   pthread_mutex_init(
     &self->mutex_destroying,
     0x00
   );
-  
+
   pthread_mutex_lock(
     &self->mutex_destroying
   );
@@ -316,11 +316,11 @@
   self->destroying = (
     0x01
   );
-  
+
   pthread_mutex_lock(
     &self->mutex_destroying
   );
-  
+
   pthread_mutex_unlock(
     &self->mutex_destroying
   );
@@ -489,12 +489,12 @@
 }
 
 - (void) render_view: (nonnull MTKView*) metal_kit_view {
-  unsigned int _frame = (
+  unsigned int index_frame = (
     self->metil->rendering_properties.frame++
   );
 
   if (
-    _frame ==
+    index_frame ==
     0x00
   ) {
     self->metil->audio.muted = (
@@ -570,9 +570,10 @@
   }
 
   self->metil->rendering_properties.fps = (
-    1000.0f /
+    0x03e8 /
     time_difference_average
   );
+
   self->index_data_buffer_frame = (
     (
       self->index_data_buffer_frame +
@@ -696,6 +697,20 @@
 
   if (
     (
+      metil->rendering_properties.mode &
+      metil_rendering_properties_mode_wireframe_full
+    ) !=
+    0x00  ) {
+    [
+      encoder_render
+      setTriangleFillMode: (
+        MTLTriangleFillModeLines
+      )
+    ];
+  }
+
+  if (
+    (
       self->metil->rendering_properties.disables &
       metil_rendering_properties_disables_rendering
     ) ==
@@ -741,7 +756,7 @@
         self->metil->rendering_properties.count_completed_frames +
         0x01
       );
-      
+
       if (
         self->destroying ==
         0x00
@@ -1121,8 +1136,11 @@
 
     self->pipelines_render[
       index_pipeline_render
-    ] = [self->metil->renderer_interface.metal_device
-      newRenderPipelineStateWithDescriptor: self->descriptor_pipeline_render
+    ] = [
+      self->metil->renderer_interface.metal_device
+      newRenderPipelineStateWithDescriptor: (
+        self->descriptor_pipeline_render
+      )
       error: (
         0x00
       )
@@ -1133,27 +1151,45 @@
 - (void) pipeline_render_library_initiliaze {
   [
     self
-    pipeline_render_initialize: metil_renderer_pipelines_render_index_library
-    function_fragment: self->metil->library.function_fragment
-    function_vertex: self->metil->library.function_vertex
+    pipeline_render_initialize: (
+      metil_renderer_pipelines_render_index_library
+    )
+    function_fragment: (
+      self->metil->library.function_fragment
+    )
+    function_vertex: (
+      self->metil->library.function_vertex
+    )
   ];
 }
 
 - (void) pipeline_render_wireframe_initialize {
   [
     self
-    pipeline_render_initialize: metil_renderer_pipelines_render_index_wireframe
-    function_fragment: self->metil->library.function_fragment_wireframe
-    function_vertex: self->metil->library.function_vertex_wireframe
+    pipeline_render_initialize: (
+      metil_renderer_pipelines_render_index_wireframe
+    )
+    function_fragment: (
+      self->metil->library.function_fragment_wireframe
+    )
+    function_vertex: (
+      self->metil->library.function_vertex_wireframe
+    )
   ];
 }
 
 - (void) pipeline_render_fps_display_initiliaze {
   [
     self
-    pipeline_render_initialize: metil_renderer_pipelines_render_index_fps_display
-    function_fragment: self->metil->library.function_fragment_fps_display
-    function_vertex: self->metil->library.function_vertex_fps_display
+    pipeline_render_initialize: (
+      metil_renderer_pipelines_render_index_fps_display
+    )
+    function_fragment: (
+      self->metil->library.function_fragment_fps_display
+    )
+    function_vertex: (
+      self->metil->library.function_vertex_fps_display
+    )
   ];
 }
 
@@ -1591,7 +1627,8 @@
           );
           ++index_group_renderable
         ) {
-          [self
+          [
+            self
             render_renderable: metil_group->renderables[
               index_group_renderable
             ]
@@ -1607,22 +1644,40 @@
       );
 
       if (
-        self->metil->rendering_properties.mode &
-        metil_rendering_properties_mode_default
-      ) {
+        (
+          self->metil->rendering_properties.mode &
+          (
+            metil_rendering_properties_mode_default
+|
+            metil_rendering_properties_mode_wireframe_full
+          )
+        ) !=
+        0x00      ) {
         [
           self
-          render_object: metil_object
+          render_object: (
+            metil_object
+          )
         ];
       }
 
       if (
-        self->metil->rendering_properties.mode &
-        metil_rendering_properties_mode_wireframe
-      ) {
-        [
+        (
+          self->metil->rendering_properties.mode &
+          metil_rendering_properties_mode_wireframe
+        ) &&
+        (
+          (
+            self->metil->rendering_properties.mode &
+            metil_rendering_properties_mode_wireframe_full
+          ) ==
+          0x00
+        )
+      ) {        [
           self
-          render_object_wireframe: metil_object
+          render_object_wireframe: (
+            metil_object
+          )
         ];
       }
       break;
@@ -1713,7 +1768,9 @@
 
     [
       self
-      render_renderable: metil_renderable
+      render_renderable: (
+        metil_renderable
+      )
     ];
   }
 }

--- a/sources/metil_rendering/metil_renderer_data_object.c
+++ b/sources/metil_rendering/metil_renderer_data_object.c
@@ -6,11 +6,11 @@ void metil_renderer_data_object_initialize(
   metil_renderer_data_object->position.x = (
     0x00
   );
-  
+
   metil_renderer_data_object->position.y = (
     0x00
   );
-  
+
   metil_renderer_data_object->position.z = (
     0x00
   );
@@ -18,11 +18,11 @@ void metil_renderer_data_object_initialize(
   metil_renderer_data_object->size.x = (
     0x00
   );
-  
+
   metil_renderer_data_object->size.y = (
     0x00
   );
-  
+
   metil_renderer_data_object->size.z = (
     0x00
   );
@@ -30,15 +30,15 @@ void metil_renderer_data_object_initialize(
   metil_renderer_data_object->colour.x = (
     0x01
   );
-  
+
   metil_renderer_data_object->colour.y = (
     0x01
   );
-  
+
   metil_renderer_data_object->colour.z = (
     0x01
   );
-  
+
   metil_renderer_data_object->colour.w = (
     0x01
   );

--- a/sources/metil_rendering/metil_rendering_properties.c
+++ b/sources/metil_rendering/metil_rendering_properties.c
@@ -38,15 +38,15 @@ void metil_rendering_properties_initialize(
   metil_rendering_properties->colour_clear.x = (
     0x00
   );
-  
+
   metil_rendering_properties->colour_clear.y = (
     0x00
   );
-  
+
   metil_rendering_properties->colour_clear.z = (
     0x00
   );
-  
+
   metil_rendering_properties->colour_clear.w = (
     0x01
   );


### PR DESCRIPTION
- `metil_rendering_properties_mode_wireframe_full`
- - this just sets the triangle fill mode
- - - keeps vertex positioning since it doesnt use the wireframe vertex shader
- - - keeps colours since it doesnt use the wireframe fragment shader
- - - not a good way to combine this with normal rendering since the lined triangles are hidden by the filled triangles
- - if both `metil_rendering_properties_mode_wireframe_full` and `metil_rendering_properties_mode_wireframe` are set then only `metil_rendering_properties_mode_wireframe_full` is rendered
- - if `metil_rendering_properties_mode_wireframe_full` is set but `metil_rendering_properties_mode_default` is not then things are still rendered

## examples

### `metil_rendering_properties_mode_wireframe`

<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 41 23" src="https://github.com/user-attachments/assets/544c7251-b864-4e38-b805-bca50160b86d" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 28 29" src="https://github.com/user-attachments/assets/5ceb754a-4435-479e-9f0d-0590535bacde" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 28 39" src="https://github.com/user-attachments/assets/595edd61-ebc0-4af6-bf39-6ea859bc6a20" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 28 42" src="https://github.com/user-attachments/assets/c59fed9c-d3a3-4c76-8c8d-09c8523f510c" />


### `metil_rendering_properties_mode_default` | `metil_rendering_properties_mode_wireframe`

<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 41 15" src="https://github.com/user-attachments/assets/74690653-0f43-41c3-93e7-b3a5a0e3f1cf" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 32 40" src="https://github.com/user-attachments/assets/78dfbdbd-bf4e-4163-890e-31fd128a447d" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 33 02" src="https://github.com/user-attachments/assets/c563646f-924b-47a1-98b4-756457fe7f3d" />


### `metil_rendering_properties_mode_wireframe_full`

<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 41 07" src="https://github.com/user-attachments/assets/7a7b7427-1c22-4c09-a6e4-560b51c32f1a" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 37 42" src="https://github.com/user-attachments/assets/360ae1ea-96e5-4330-871d-d31096e36d21" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 37 28" src="https://github.com/user-attachments/assets/2499720e-08c8-448b-89df-e3228ff54bff" />
<img width="1966" height="1250" alt="Screenshot 2026-05-19 at 17 37 22" src="https://github.com/user-attachments/assets/82a0396a-78a0-4009-ac7e-80e3b6dbbf8e" />
