### PR TITLE
[bug] Fix frame overlapping

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -76,6 +76,8 @@
 
 - (void) after_scene_change;
 
+- (id<MTLLogState> _Nullable) log_state_create;
+
 - (void) command_queue_initialize;
 
 - (void) data_buffer_frames_initialize;

--- a/include/metil_rendering/metil_rendering_properties.h
+++ b/include/metil_rendering/metil_rendering_properties.h
@@ -28,7 +28,7 @@ struct metil_rendering_properties {
   struct metil_camera camera;
 
   unsigned int frame;
-  signed char count_completed_frames;
+  unsigned int count_completed_frames;
   pthread_mutex_t mutex_frame;
 
   float brightness;

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -222,9 +222,81 @@
 
 - (void) after_scene_change {}
 
+- (id<MTLLogState>) log_state_create {
+  return (
+    0x00
+  );
+
+  MTLLogStateDescriptor* descriptor_log_state = [
+    [
+      MTLLogStateDescriptor
+      alloc
+    ]
+    init
+  ];
+  
+  descriptor_log_state.level = (
+    MTLLogLevelDebug
+  );
+  
+  id<MTLLogState> log_state = [
+    self->metil->renderer_interface.metal_device
+    newLogStateWithDescriptor: (
+      descriptor_log_state
+    )
+    error: (
+      0x00
+    )
+  ];
+  
+  [
+    descriptor_log_state
+    release
+  ];
+  
+  [
+    log_state
+    addLogHandler: ^(
+      NSString* subsystem,
+      NSString* category,
+      MTLLogLevel level_log,
+      NSString* log
+    ) {
+      printf("%s\n","sfsf");
+    }
+  ];
+  
+  return (
+    log_state
+  ); 
+}
+
 - (void) command_queue_initialize {
-  self->command_queue = [self->metil->renderer_interface.metal_device
-    newCommandQueue
+  MTLCommandQueueDescriptor* descriptor_command_queue = [
+    [
+      MTLCommandQueueDescriptor
+      alloc
+    ]
+    init
+  ];
+  
+  descriptor_command_queue.logState = (
+    [
+      self
+      log_state_create
+    ] 
+  );
+  
+  self->command_queue = [
+    self->metil->renderer_interface.metal_device
+    newCommandQueueWithDescriptor: (
+      descriptor_command_queue
+    )
+  ];
+  
+  [
+    descriptor_command_queue
+    release
   ];
 }
 
@@ -248,7 +320,9 @@
           struct metil_renderer_data_frame
         )
       )
-      options: MTLResourceStorageModeShared
+      options: (
+        MTLResourceStorageModeShared
+      )
     ];
   }
 }
@@ -489,12 +563,18 @@
 }
 
 - (void) render_view: (nonnull MTKView*) metal_kit_view {
+  if (
+    self->metil->rendering_properties.frame !=
+    self->metil->rendering_properties.count_completed_frames
+  ) {
+    return;
+  }
+
   unsigned int index_frame = (
     self->metil->rendering_properties.frame++
   );
-
-  if (
-    index_frame ==
+  
+  if (    index_frame ==
     0x00
   ) {
     self->metil->audio.muted = (
@@ -581,15 +661,39 @@
     ) %
     metil_count_max_frames
   );
+  
+  MTLCommandBufferDescriptor* descriptor_command_buffer = [
+    [
+      MTLCommandBufferDescriptor
+      alloc
+    ]
+    init
+  ];
+  
+  descriptor_command_buffer.logState = (
+    [
+      self
+      log_state_create
+    ]
+  );
 
   id<MTLCommandBuffer> command_buffer = [
     self->command_queue
-    commandBuffer
+    commandBufferWithDescriptor: (
+      descriptor_command_buffer
+    )
+  ];
+  
+  [
+    descriptor_command_buffer
+    release
   ];
 
   MTLRenderPassDescriptor* descriptor_render_pass = (
     metal_kit_view.currentRenderPassDescriptor
   );
+     
+  // renderTargetWidth
 
   descriptor_render_pass.colorAttachments[
     0x00
@@ -700,11 +804,19 @@
       metil->rendering_properties.mode &
       metil_rendering_properties_mode_wireframe_full
     ) !=
-    0x00  ) {
+    0x00
+  ) {
     [
       encoder_render
       setTriangleFillMode: (
         MTLTriangleFillModeLines
+      )
+    ];
+  } else {
+    [
+      encoder_render
+      setTriangleFillMode: (
+        MTLTriangleFillModeFill
       )
     ];
   }
@@ -756,8 +868,7 @@
         self->metil->rendering_properties.count_completed_frames +
         0x01
       );
-
-      if (
+                  if (
         self->destroying ==
         0x00
       ) {
@@ -1547,7 +1658,8 @@
     self->objects_fps_display[
       index_object_fps_display
     ].position.y = (
-      0.971f +      self->objects_fps_display[
+      0.971f +
+      self->objects_fps_display[
         index_object_fps_display
       ].mesh.size.y /
       0x02
@@ -1835,9 +1947,11 @@
 {
   [
     encoder_render
-    setRenderPipelineState: self->pipelines_render[
-      index_pipeline_render
-    ]
+    setRenderPipelineState: (
+      self->pipelines_render[
+        index_pipeline_render
+      ]
+    )
   ];
 
   if (
@@ -1846,12 +1960,16 @@
   ) {
     [
       encoder_render
-      setDepthStencilState: self->depth_state
+      setDepthStencilState: (
+        self->depth_state
+      )
     ];
   } else {
     [
       encoder_render
-      setDepthStencilState: self->depth_state_writes_disabled
+      setDepthStencilState: (
+        self->depth_state_writes_disabled
+      )
     ];
   }
 
@@ -1870,8 +1988,12 @@
         self->index_data_buffer_frame
       ]
     )
-    offset: 0x00
-    atIndex: metil_renderer_vertex_index_parameter_data_frame
+    offset: (
+      0x00
+    )
+    atIndex: (
+      metil_renderer_vertex_index_parameter_data_frame
+    )
   ];
 
   for (
@@ -1969,7 +2091,8 @@
     metil_object->visible ==
     0x01
   ) {
-    [self
+    [
+      self
       render_encode_draw: metil_object->buffers_vertex
       length_buffers_vertex: metil_object->length_buffers_vertex
       buffers_fragment: metil_object->buffers_fragment
@@ -1991,7 +2114,8 @@
     metil_object->visible ==
     0x01
   ) {
-    [self
+    [
+      self
       render_encode_draw: metil_object->buffers_vertex
       length_buffers_vertex: metil_object->length_buffers_vertex
       buffers_fragment: metil_object->buffers_fragment

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -234,11 +234,11 @@
     ]
     init
   ];
-  
+
   descriptor_log_state.level = (
     MTLLogLevelDebug
   );
-  
+
   id<MTLLogState> log_state = [
     self->metil->renderer_interface.metal_device
     newLogStateWithDescriptor: (
@@ -248,12 +248,12 @@
       0x00
     )
   ];
-  
+
   [
     descriptor_log_state
     release
   ];
-  
+
   [
     log_state
     addLogHandler: ^(
@@ -265,10 +265,10 @@
       printf("%s\n","sfsf");
     }
   ];
-  
+
   return (
     log_state
-  ); 
+  );
 }
 
 - (void) command_queue_initialize {
@@ -279,21 +279,21 @@
     ]
     init
   ];
-  
+
   descriptor_command_queue.logState = (
     [
       self
       log_state_create
-    ] 
+    ]
   );
-  
+
   self->command_queue = [
     self->metil->renderer_interface.metal_device
     newCommandQueueWithDescriptor: (
       descriptor_command_queue
     )
   ];
-  
+
   [
     descriptor_command_queue
     release
@@ -573,8 +573,8 @@
   unsigned int index_frame = (
     self->metil->rendering_properties.frame++
   );
-  
-  if 
+
+  if
     index_frame ==
     0x00
   ) {
@@ -662,7 +662,7 @@
     ) %
     metil_count_max_frames
   );
-  
+
   MTLCommandBufferDescriptor* descriptor_command_buffer = [
     [
       MTLCommandBufferDescriptor
@@ -670,7 +670,7 @@
     ]
     init
   ];
-  
+
   descriptor_command_buffer.logState = (
     [
       self
@@ -684,7 +684,7 @@
       descriptor_command_buffer
     )
   ];
-  
+
   [
     descriptor_command_buffer
     release
@@ -867,7 +867,7 @@
         self->metil->rendering_properties.count_completed_frames +
         0x01
       );
-      
+
       if (
         self->destroying ==
         0x00

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -574,7 +574,7 @@
     self->metil->rendering_properties.frame++
   );
 
-  if
+  if (
     index_frame ==
     0x00
   ) {

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -574,7 +574,8 @@
     self->metil->rendering_properties.frame++
   );
   
-  if (    index_frame ==
+  if 
+    index_frame ==
     0x00
   ) {
     self->metil->audio.muted = (
@@ -692,8 +693,6 @@
   MTLRenderPassDescriptor* descriptor_render_pass = (
     metal_kit_view.currentRenderPassDescriptor
   );
-     
-  // renderTargetWidth
 
   descriptor_render_pass.colorAttachments[
     0x00
@@ -868,7 +867,8 @@
         self->metil->rendering_properties.count_completed_frames +
         0x01
       );
-                  if (
+      
+      if (
         self->destroying ==
         0x00
       ) {

--- a/sources/metil_rendering/metil_rendering_properties.c
+++ b/sources/metil_rendering/metil_rendering_properties.c
@@ -20,7 +20,7 @@ void metil_rendering_properties_initialize(
   );
 
   metil_rendering_properties->count_completed_frames = (
-    metil_count_max_frames
+    0x00
   );
 
   metil_camera_initialize(


### PR DESCRIPTION
- only render frames if the frame index is equal to the count of completed frames
- - this *shouldnt* occur, but, it does appear that extra `draw` calls are being sent.. they should only be called when the command buffer is completed, yet, with large renderable counts, there does appear to be extra calls to `draw` which are not manually called.
- - - this check for index frame vs count completed frame prevents the extra calls from actually running
- add in preliminary log states to descriptors

heres `fog` with 60000 renderables, couldn't take screenshots because the whole computer just freezes

<img width="660" height="651" alt="IMG_8298" src="https://github.com/user-attachments/assets/57dda1b9-c3d5-4e08-bb08-1f5fda74d647" />

also this fixes [gol](https://github.com/alic3dev/game_of_life)

https://github.com/user-attachments/assets/ccfc0600-e3e3-4334-993d-d04690e1d822

<img width="1966" height="1250" alt="Screenshot 2026-05-20 at 23 01 31" src="https://github.com/user-attachments/assets/abea89b9-c733-4721-88d7-23745a5a9973" />

