### PR TITLE
[dev] `metil_renderer`:fix->{`if`:statement};

### DIFF
--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -574,7 +574,7 @@
     self->metil->rendering_properties.frame++
   );
 
-  if
+  if (
     index_frame ==
     0x00
   ) {


### PR DESCRIPTION
- `metil_renderer`:fix->{`if`:statement};
- - accidentally deleted a `(` there, oops :)