### PR TITLE
[bug|dev] Metil renderer first person camera fix

### DIFF
--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1343,10 +1343,47 @@
     poll_frame
   );
 
+  struct math_c_vector2_float rotation_sine = {
+    .x = (
+      math_c_sine(
+        metil_player->rotation.x,
+        math_c_pi
+      )
+    ),
+    .y = (
+      math_c_sine(
+        metil_player->rotation.y,
+        math_c_pi
+      )
+    )
+  };
+
+  struct math_c_vector2_float rotation_cosine = {
+    .x = (
+      math_c_cosine(
+        metil_player->rotation.x,
+        math_c_pi
+      )
+    ),
+    .y = (
+      math_c_cosine(
+        metil_player->rotation.y,
+        math_c_pi
+      )
+    )
+  };
+
   matrix_float4x4 matrix_player_rotation_x = (matrix_float4x4) {{
     { 0x01, 0x00, 0x00, 0x00 },
-    { 0x00, math_c_cosine(metil_player->rotation.x, math_c_pi), -math_c_sine(metil_player->rotation.x, math_c_pi), 0x00 },
-    { 0x00, math_c_sine(metil_player->rotation.x, math_c_pi), math_c_cosine(metil_player->rotation.x, math_c_pi), 0x00 },
+    { 0x00, rotation_cosine.x, -rotation_sine.x, 0x00 },
+    { 0x00, rotation_sine.x, rotation_cosine.x, 0x00 },
+    { 0x00, 0x00, 0x00, 0x01 }
+  }};
+
+  matrix_float4x4 matrix_player_rotation_y = (matrix_float4x4) {{
+    { rotation_cosine.y, 0x00, rotation_sine.y, 0x00 },
+    { 0x00, 0x01, 0x00, 0x00 },
+    { rotation_sine.y, 0x00, -rotation_cosine.y, 0x00 },
     { 0x00, 0x00, 0x00, 0x01 }
   }};
 
@@ -1372,13 +1409,6 @@
       ].y
     );
   }
-
-  matrix_float4x4 matrix_player_rotation_y = (matrix_float4x4) {{
-    { math_c_cosine(metil_player->rotation.y, math_c_pi), 0x00, math_c_sine(metil_player->rotation.y, math_c_pi), 0x00 },
-    { 0x00, 0x01, 0x00, 0x00 },
-    { math_c_sine(metil_player->rotation.y, math_c_pi), 0x00, -math_c_cosine(metil_player->rotation.y, math_c_pi), 0x00 },
-    { 0x00, 0x00, 0x00, 0x01 }
-  }};
 
   matrix_float4x4 matrix_player_projection = matrix_multiply(
     self->metil->rendering_properties.camera.matrix_viewport_projection,

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1394,7 +1394,8 @@
     matrix_player_rotation_x.columns[
       0x03
     ].y = (
-      self->metil->rendering_properties.camera.height * (
+      self->metil->rendering_properties.camera.height *
+      (
         1.0f -
         -metil_player->rotation.x /
         math_c_pi_half
@@ -1794,7 +1795,8 @@
             metil_rendering_properties_mode_wireframe_full
           )
         ) !=
-        0x00      ) {
+        0x00
+      ) {
         [
           self
           render_object: (
@@ -1815,7 +1817,8 @@
           ) ==
           0x00
         )
-      ) {        [
+      ) {
+        [
           self
           render_object_wireframe: (
             metil_object

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1409,6 +1409,12 @@
         0x03
       ].y
     );
+  } else {
+    matrix_player_rotation_x.columns[
+      0x03
+    ].z = (
+      0x01
+    );
   }
 
   matrix_float4x4 matrix_player_projection = matrix_multiply(


### PR DESCRIPTION
- `metil_renderer`
- - fix first person camera z axis offset
- - - due to the render viewport of metal being a `-0x01` to `0x01` cube, that meant that the camera was actually rotating around a radius of `0x01` units rather than everything rotating around the camera
- - - the camera now stays in a static position and everything within the viewport rotates around it rather than the camera rotating around a `0x01` radius
- - only calculate rotation sines and cosines once


https://github.com/user-attachments/assets/c25e66d7-cc92-4125-a288-0d60f42ec548

