### PR TITLE
[enh] Metil editor vertex additions

### DIFF
--- a/tools/metil_editor/include/metil_editor_mode.h
+++ b/tools/metil_editor/include/metil_editor_mode.h
@@ -1,0 +1,9 @@
+#ifndef __metil_tools_metil_editor_metil_editor_mode_h
+#define __metil_tools_metil_editor_metil_editor_mode_h
+
+enum metil_editor_mode {
+  metil_editor_mode_vertices = 0b10000000,
+  metil_editor_mode_indices  = 0b01000000
+};
+
+#endif

--- a/tools/metil_editor/include/metil_editor_scene_data.h
+++ b/tools/metil_editor/include/metil_editor_scene_data.h
@@ -1,12 +1,16 @@
 #ifndef __metil_tools_metil_editor_metil_editor_scene_data_h
 #define __metil_tools_metil_editor_metil_editor_scene_data_h
 
+#include <metil_editor_mode.h>
+
 struct metil_editor_scene_data {
   struct math_c_vector3_float position;
 
   struct math_c_vector3_float position_player;
 
   unsigned char movement_free;
+
+  unsigned char mode;
 };
 
 #endif

--- a/tools/metil_editor/sources/metil_editor.m
+++ b/tools/metil_editor/sources/metil_editor.m
@@ -56,7 +56,7 @@ void metil_editor_renderer_on_initialize(
       newFunctionWithName: @"metil_editor_cursor_vertex"
     ]
   ];
-  
+
   metil_editor_index_pipeline_render->grid_lines = [
     metil->renderer_interface.renderer
     pipeline_add: [

--- a/tools/metil_editor/sources/metil_editor_scene.m
+++ b/tools/metil_editor/sources/metil_editor_scene.m
@@ -32,7 +32,7 @@ void metil_editor_scene_initialize(
     metil_scene,
     metil_editor_scene_length_renderables
   );
-  
+
   metil_scene->data = (
     clic3_memory_allocate_raw(
       sizeof(
@@ -40,19 +40,19 @@ void metil_editor_scene_initialize(
       )
     )
   );
-  
+
   struct metil_editor_scene_data* metil_editor_scene_data = (
     metil_scene->data
   );
-  
+
   metil_scene->poll = (
     metil_editor_scene_poll
   );
-  
+
   metil_scene->destroy = (
     metil_editor_scene_destroy
   );
-  
+
   for (
     unsigned char index_renderable = (
       0x00
@@ -75,7 +75,7 @@ void metil_editor_scene_initialize(
           index_renderable,
           metil_renderable_type_group
         );
-        
+
         break;
       }
       default: {
@@ -84,66 +84,66 @@ void metil_editor_scene_initialize(
           index_renderable,
           metil_renderable_type_object
         );
-        
+
         break;
       }
     }
   }
-  
+
   struct metil_group* metil_group_grids = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_group_grids
     ].renderable
   );
-  
+
   struct metil_object* metil_object_grid_lines = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_grid_lines
     ].renderable
   );
-  
+
   struct metil_object* metil_object_lines = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_lines
     ].renderable
   );
-  
+
   struct metil_object* metil_object_points = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_points
     ].renderable
   );
-  
+
   struct metil_object* metil_object_cursor = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_cursor
     ].renderable
   );
-  
+
   struct metil_group* metil_group_text_position_cursor = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_group_text_position_cursor
     ].renderable
   );
-  
+
   struct metil_group* metil_group_text_position_vertex = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_group_text_position_vertex
     ].renderable
   );
-  
+
   struct metil_group* metil_group_text_length_vertices = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_group_text_length_vertices
     ].renderable
   );
-  
+
   metil_group_add_length_initialize(
     metil_group_grids,
     0x06,
     metil_renderable_type_object
   );
-  
+
   for (
     unsigned char index_grid = (
       0x00
@@ -159,12 +159,12 @@ void metil_editor_scene_initialize(
         index_grid
       ]->renderable
     );
-    
+
     unsigned char subgrid = (
       index_grid %
       0x02
     );
-    
+
     unsigned long int length_cells = (
       (
         subgrid ==
@@ -173,7 +173,7 @@ void metil_editor_scene_initialize(
       ? 0x64
       : 0x03e8
     );
-      
+
     metil_mesh_celled_grid_initialize(
       &metil_object_grid->mesh,
       (struct math_c_vector2_float) {
@@ -193,18 +193,18 @@ void metil_editor_scene_initialize(
         )
       }
     );
-    
+
     metil_object_buffers_initialize(
       metil_object_grid,
       metil->renderer_interface.metal_device
     );
-    
+
     struct metil_renderer_data_object* metil_renderer_data_object = (
       metil_object_grid->buffers_vertex[
         metil_object_buffer_default_index_data
       ].buffer.contents
     );
-      
+
     metil_renderer_data_object->colour.w = (
       (
         subgrid ==
@@ -213,7 +213,7 @@ void metil_editor_scene_initialize(
       ? 0.025f
       : 0.0125f
     );
-    
+
     switch (
       index_grid /
       0x02
@@ -222,36 +222,36 @@ void metil_editor_scene_initialize(
         metil_object_grid->rotation.x = (
           math_c_pi_half
         );
-        
+
         break;
       }
       case 0x01: {
         metil_object_grid->rotation.y = (
           math_c_pi_half
         );
-        
+
         break;
       }
       default: {
         break;
       }
     }
-    
+
     metil_object_grid->type_primitive = (
       MTLPrimitiveTypeLine
     );
-    
+
     metil_object_grid->depth_disabled = (
       0x01
     );
   }
-  
+
   metil_mesh_initialize_with_lengths(
     &metil_object_grid_lines->mesh,
     0x06,
     0x06
   );
-  
+
   for (
     unsigned char index_vertex = (
       0x00
@@ -273,17 +273,17 @@ void metil_editor_scene_initialize(
       ?  0x01
       : -0x01
     );
-    
+
     unsigned char index_axis = (
       index_vertex /
       0x02
     );
-    
+
     metil_object_grid_lines->mesh.vertices[
       index_vertex
     ].x = (
       (
-        index_axis == 
+        index_axis ==
         0x00
       )
       ? (
@@ -292,7 +292,7 @@ void metil_editor_scene_initialize(
       )
       : 0x00
     );
-  
+
     metil_object_grid_lines->mesh.vertices[
       index_vertex
     ].y = (
@@ -306,7 +306,7 @@ void metil_editor_scene_initialize(
       )
       : 0x00
     );
-  
+
     metil_object_grid_lines->mesh.vertices[
       index_vertex
     ].z = (
@@ -320,62 +320,129 @@ void metil_editor_scene_initialize(
       )
       : 0x00
     );
-  
+
     metil_object_grid_lines->mesh.vertices[
       index_vertex
     ].w = (
       0x01
     );
-    
+
     metil_object_grid_lines->mesh.indices[
       index_vertex
     ] = (
       index_vertex
     );
   }
-  
+
   metil_object_buffers_initialize(
     metil_object_grid_lines,
     metil->renderer_interface.metal_device
   );
-  
+
   metil_object_grid_lines->index_pipeline_render = (
     metil_editor_index_pipeline_render->grid_lines
   );
-  
+
   metil_object_grid_lines->type_primitive = (
     MTLPrimitiveTypeLine
   );
-  
+
   metil_object_grid_lines->depth_disabled = (
     0x01
   );
-  
+
   metil_mesh_initialize(
     &metil_object_lines->mesh
   );
-  
+
   metil_mesh_initialize(
     &metil_object_points->mesh
   );
-  
-  metil_object_buffers_initialize(
+
+  metil_object_points->mesh.size.x = (
+    0x0a
+  );
+
+  metil_object_buffers_add(
     metil_object_lines,
+    metil->renderer_interface.metal_device,
+    metil_object_buffer_type_vertex
+  );
+
+  metil_object_buffers_add(
+    metil_object_lines,
+    metil->renderer_interface.metal_device,
+    metil_object_buffer_type_vertex
+  );
+
+  metil_object_lines->type_primitive = (
+    MTLPrimitiveTypeLineStrip
+  );
+
+  metil_object_points->type_primitive = (
+    MTLPrimitiveTypePoint
+  );
+
+  metil_object_points->index_pipeline_render = (
+    metil_editor_index_pipeline_render->cursor
+  );
+  metil_object_lines->indices = [    metil->renderer_interface.metal_device
+    newBufferWithLength: (
+      sizeof(
+        unsigned int
+      ) *
+      0xffff
+    )
+    options: (
+      MTLResourceStorageModeShared
+    )
+  ];
+
+  metil_object_lines->buffers_vertex[
+    metil_object_buffer_default_index_vertices
+  ].buffer = [
     metil->renderer_interface.metal_device
+    newBufferWithLength: (
+      sizeof(
+        struct math_c_vector4_float
+      ) *
+      0xffff
+    )
+    options: (
+      MTLResourceStorageModeShared
+    )
+  ];
+
+  metil_object_lines->buffers_vertex[
+    metil_object_buffer_default_index_data
+  ].buffer = [
+    metil->renderer_interface.metal_device
+    newBufferWithLength: (
+      sizeof(
+        struct metil_renderer_data_object
+      )    )
+    options: (
+      MTLResourceStorageModeShared
+    )
+  ];
+
+  metil_renderer_data_object_initialize(
+    metil_object_lines->buffers_vertex[
+      metil_object_buffer_default_index_data
+    ].buffer.contents
   );
-  
   metil_object_buffers_add(
     metil_object_points,
     metil->renderer_interface.metal_device,
     metil_object_buffer_type_vertex
   );
-  
+
   metil_object_buffers_add(
     metil_object_points,
     metil->renderer_interface.metal_device,
     metil_object_buffer_type_vertex
   );
-  
+
   metil_object_points->buffers_vertex[
     0x00
   ].buffer = (
@@ -383,50 +450,57 @@ void metil_editor_scene_initialize(
       0x00
     ].buffer
   );
-  
+
   metil_object_points->buffers_vertex[
     0x01
   ].buffer = (
     metil_object_lines->buffers_vertex[
       0x01
     ].buffer
-  );  
-
-  metil_object_indices_initialize(
-    metil_object_points,
-    metil->renderer_interface.metal_device
   );
-  
+
+  metil_object_points->indices = [    metil->renderer_interface.metal_device
+    newBufferWithLength: (
+      sizeof(
+        unsigned int
+      ) *
+      0xffff
+    )
+    options: (
+      MTLResourceStorageModeShared
+    )
+  ];
+
   metil_mesh_initialize_with_lengths(
     &metil_object_cursor->mesh,
     0x01,
     0x01
   );
-  
+
   metil_object_cursor->mesh.vertices[
     0x00
   ].x = (
     0x00
   );
-  
+
   metil_object_cursor->mesh.vertices[
     0x00
   ].y = (
     0x00
   );
-  
+
   metil_object_cursor->mesh.vertices[
     0x00
   ].z = (
     0x00
   );
-  
+
   metil_object_cursor->mesh.vertices[
     0x00
   ].w = (
     0x01
   );
-  
+
   metil_object_cursor->mesh.indices[
     0x00
   ] = (
@@ -436,56 +510,60 @@ void metil_editor_scene_initialize(
     metil_object_cursor,
     metil->renderer_interface.metal_device
   );
-  
+
   struct metil_renderer_data_object* metil_renderer_data_object_cursor = (
     metil_object_cursor->buffers_vertex[
       metil_object_buffer_default_index_data
     ].buffer.contents
   );
-  
+
   metil_renderer_data_object_cursor->colour.w = (
     0.25f
   );
-  
+
   metil_object_cursor->type_primitive = (
     MTLPrimitiveTypePoint
-  );  
-  
+  );
+
   metil_object_cursor->index_pipeline_render = (
     metil_editor_index_pipeline_render->cursor
-  );  
-  
+  );
+
   metil_object_lines->visible = (
     0x00
   );
-  
+
   metil_object_points->visible = (
     0x00
   );
-  
+
   metil_scene->player.position.x = (
     0x0a
   );
-  
+
   metil_scene->player.position.y = (
     0x0a
   );
-  
+
   metil_scene->player.position.z = -(
     0x0a
   );
-  
+
   metil_scene->player.poll_input = (
     metil_player_poll_input_free_flying_locked
   );
-  
+
   metil_scene->player.rotation.y = (
     math_c_pi_half /
     0x02
   );
-  
+
   metil_editor_scene_data->movement_free = (
     0x01
+  );
+
+  metil_editor_scene_data->mode = (
+    metil_editor_mode_vertices
   );
 }
 
@@ -497,35 +575,35 @@ void metil_editor_scene_poll(
     metil,
     metil_scene
   );
-  
+
   struct metil_editor_scene_data* metil_editor_scene_data = (
     metil_scene->data
   );
-  
+
   struct metil_group* metil_group_grids = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_group_grids
     ].renderable
   );
-  
+
   struct metil_object* metil_object_lines = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_lines
     ].renderable
   );
-  
+
   struct metil_object* metil_object_points = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_points
     ].renderable
   );
-  
+
   struct metil_object* metil_object_cursor = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_cursor
     ].renderable
   );
-  
+
   if (
     metil->input.keydown_map[
       metil_keycode_g
@@ -543,13 +621,13 @@ void metil_editor_scene_poll(
           0x00
         ]->renderable
       );
-      
+
       struct metil_object* metil_object_grid_sub_x = (
         metil_group_grids->renderables[
           0x01
         ]->renderable
       );
-      
+
       metil_object_grid_x->visible = (
         (
           metil_object_grid_x->visible ==
@@ -558,17 +636,17 @@ void metil_editor_scene_poll(
         ? 0x01
         : 0x00
       );
-      
+
       metil_object_grid_sub_x->visible = (
         metil_object_grid_x->visible
       );
-      
+
       metil->input.keydown_map[
         metil_keycode_x
       ] = (
         0x00
       );
-    }    
+    }
     if (
       metil->input.keydown_map[
         metil_keycode_y
@@ -580,13 +658,13 @@ void metil_editor_scene_poll(
           0x02
         ]->renderable
       );
-      
+
       struct metil_object* metil_object_grid_sub_y = (
         metil_group_grids->renderables[
           0x03
         ]->renderable
       );
-      
+
       metil_object_grid_y->visible = (
         (
           metil_object_grid_y->visible ==
@@ -595,18 +673,18 @@ void metil_editor_scene_poll(
         ? 0x01
         : 0x00
       );
-      
+
       metil_object_grid_sub_y->visible = (
         metil_object_grid_y->visible
       );
-      
+
       metil->input.keydown_map[
         metil_keycode_y
       ] = (
         0x00
       );
     }
-    
+
     if (
       metil->input.keydown_map[
         metil_keycode_z
@@ -618,13 +696,13 @@ void metil_editor_scene_poll(
           0x04
         ]->renderable
       );
-      
+
       struct metil_object* metil_object_grid_sub_z = (
         metil_group_grids->renderables[
           0x05
         ]->renderable
       );
-      
+
       metil_object_grid_z->visible = (
         (
           metil_object_grid_z->visible ==
@@ -633,21 +711,18 @@ void metil_editor_scene_poll(
         ? 0x01
         : 0x00
       );
-      
+
       metil_object_grid_sub_z->visible = (
         metil_object_grid_z->visible
       );
-      
+
       metil->input.keydown_map[
         metil_keycode_z
       ] = (
         0x00
       );
     }
-  }
-  
-  if (
-    metil->input.keydown_map[
+  } else if (    metil->input.keydown_map[
       metil_keycode_tab
     ] !=
     0x00
@@ -657,7 +732,7 @@ void metil_editor_scene_poll(
     ] = (
       0x00
     );
-    
+
     metil_editor_scene_data->movement_free = (
       (
         metil_editor_scene_data->movement_free ==
@@ -665,9 +740,104 @@ void metil_editor_scene_poll(
       )
       ? 0x01
       : 0x00
-    );  
+    );
+  } else if (
+    metil_editor_scene_data->mode ==
+    metil_editor_mode_vertices
+  ) {
+    if (
+      metil->input.keydown_map[
+        metil_keycode_period
+      ] !=
+      0x00
+    ) {
+      metil_object_lines->mesh.length_vertices = (
+        metil_object_lines->mesh.length_vertices +
+        0x01
+      );
+
+      metil_object_lines->mesh.length_indices = (
+        metil_object_lines->mesh.length_indices +
+        0x01
+      );
+      metil_object_points->mesh.length_indices = (
+        metil_object_points->mesh.length_indices +
+        0x01
+      );
+
+      struct math_c_vector4_float* vertices_lines = (
+        metil_object_lines->buffers_vertex[
+          metil_object_buffer_default_index_vertices
+        ].buffer.contents
+      );
+
+      vertices_lines[
+        metil_object_lines->mesh.length_vertices -
+        0x01
+      ] = (
+        (struct math_c_vector4_float)
+        {
+          .x = (
+            metil_object_cursor->position.x
+          ),
+          .y = (
+            metil_object_cursor->position.y
+          ),
+          .z = (            metil_object_cursor->position.z
+          ),
+          .w = (
+            0x01
+          )
+        }
+      );
+
+      unsigned int* indices_lines = (
+        metil_object_lines->indices.contents
+      );
+                           unsigned int* indices_points = (
+        metil_object_points->indices.contents
+      );
+
+      indices_lines[
+        metil_object_lines->mesh.length_indices -
+        0x01
+      ] = (
+        metil_object_lines->mesh.length_vertices -
+        0x01
+      );
+
+      /*if (
+        metil_object_lines->mesh.length_vertices %
+        0x02
+      ) {
+        metil_object_lines->mesh.length_indices = (
+          metil_object_lines->mesh.length_indices +
+          0x01
+        );
+
+        indices_lines[
+          metil_object_lines->mesh.length_indices -
+          0x01
+        ] = (
+          metil_object_lines->mesh.length_vertices -
+          0x01
+        );
+      }*/
+                  indices_points[
+        metil_object_points->mesh.length_indices -
+        0x01
+      ] = (
+        metil_object_points->mesh.length_indices -
+        0x01
+      );
+                  metil->input.keydown_map[
+        metil_keycode_period
+      ] = (
+        0x00
+      );
+    }
   }
-  
+
   if (
     metil_editor_scene_data->movement_free ==
     0x00
@@ -680,7 +850,7 @@ void metil_editor_scene_poll(
       ) /
       0x04
     );
-    
+
     metil_object_cursor->position.y = (
       metil_object_cursor->position.y +
       (
@@ -689,7 +859,7 @@ void metil_editor_scene_poll(
       ) /
       0x04
     );
-    
+
     metil_object_cursor->position.z = (
       metil_object_cursor->position.z +
       (
@@ -698,7 +868,7 @@ void metil_editor_scene_poll(
       ) /
       0x04
     );
-  
+
     metil_scene->player.position = (
       metil_editor_scene_data->position_player
     );
@@ -707,7 +877,7 @@ void metil_editor_scene_poll(
       metil_scene->player.position
     );
   }
-  
+
   metil_object_cursor->mesh.size.x = (
     math_c_maximum_float(
       (
@@ -716,7 +886,7 @@ void metil_editor_scene_poll(
           math_c_vector3_distance_float_fastest(
             &metil_object_cursor->position,
             &metil_scene->player.position
-          ) 
+          )
         ) /
         0x10 *
         0x32
@@ -726,21 +896,30 @@ void metil_editor_scene_poll(
   );
 
   if (
-    metil_object_lines->mesh.length_vertices ==
-    0x00
+    metil_object_lines->mesh.length_vertices <=
+    0x01
   ) {
     metil_object_lines->visible = (
       0x00
-    ); 
+    );
   } else {
     metil_object_lines->visible = (
       0x01
     );
   }
-  
-  metil_object_points->visible = (
-    metil_object_lines->visible
-  );
+
+  if (
+    metil_object_points->mesh.length_indices ==
+    0x00
+  ) {
+    metil_object_points->visible = (
+      0x00
+    );
+  } else {
+    metil_object_points->visible = (
+      0x01
+    );
+  }
 }
 
 void metil_editor_scene_destroy(
@@ -752,13 +931,13 @@ void metil_editor_scene_destroy(
       metil_editor_scene_index_renderable_points
     ].renderable
   );
-  
+
   metil_object_points->buffers_vertex[
     0x00
   ].buffer = (
     0x00
   );
-  
+
   metil_object_points->buffers_vertex[
     0x01
   ].buffer = (


### PR DESCRIPTION
currently setting buffer sizes to allow for 0xffff items, will make a check later on that will reallocate the buffer if that limit is being approached

vertices are added with `.` when in `vertex` mode

currently every two vertices make a line (`MTLPrimitiveTypeLineStrip`) as well as every singular vertex making a `MTLPrimitiveTypePoint`



https://github.com/user-attachments/assets/6c23c514-b2b0-4420-8328-c53dd2cfd408



https://github.com/user-attachments/assets/50ad74dd-1d04-48c0-86f7-c86749263b97

