### PR TITLE
[enh] `metil_renderer`:ios:only_render_when_app_is_active

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -144,9 +144,14 @@ void metil_renderer_poll_object(
   struct metil_renderable* _Nonnull
 );
 
+void* _Nullable metil_renderer_thread_draw(
+  void* _Nonnull
+);
+
 void* _Nullable metil_renderer_thread_poll_object(
   void* _Nonnull
 );
+
 void metil_renderer_after_scene_change(
   struct metil* _Nonnull,
   int,

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -144,9 +144,11 @@ void metil_renderer_poll_object(
   struct metil_renderable* _Nonnull
 );
 
+#if target_os_ios
 void* _Nullable metil_renderer_thread_draw(
   void* _Nonnull
 );
+#endif
 
 void* _Nullable metil_renderer_thread_poll_object(
   void* _Nonnull

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1,5 +1,6 @@
 #include <metil_rendering/metil_renderer.h>
 
+#include <metil_application/metil_application.h>
 #include <metil_audio/metil_audio.h>
 #include <metil_audio/metil_audio_data.h>
 #include <metil_configuration/metil_configuration.h>
@@ -262,7 +263,7 @@
       MTLLogLevel level_log,
       NSString* log
     ) {
-      printf("%s\n","sfsf");
+      // printf("%s\n",log);
     }
   ];
 
@@ -553,6 +554,69 @@
       self->metil->rendering_properties.frame
     )
   ];
+
+  #if target_os_ios
+  metil_application* metil_ui_application = (
+    (metil_application*)
+    [
+      UIApplication
+      sharedApplication
+    ]
+  );
+
+  unsigned char state_application = [
+    metil_ui_application
+    applicationState
+  ];
+
+  if (
+    state_application >
+    0x01
+  ) {
+    if (
+      self->destroying ==
+      0x00
+    ) {
+      struct timespec time_sleep = {
+        .tv_sec = (
+          0x00
+        ),
+        .tv_nsec = (
+          0x05f5e100
+        )
+      };
+
+      struct timespec time_remaining = {
+        .tv_sec = (
+          0x00
+        ),
+        .tv_nsec = (
+          0x00
+        )
+      };
+
+      nanosleep(
+        &time_sleep,
+        &time_remaining
+      );
+
+      pthread_t thread_draw;
+
+      pthread_create(
+        &thread_draw,
+        0x00,
+        metil_renderer_thread_draw,
+        metal_kit_view
+      );
+    } else {
+      pthread_mutex_unlock(
+        &self->mutex_destroying
+      );
+    }
+
+    return;
+  }
+  #endif
 
   [
     self
@@ -1897,8 +1961,7 @@
 }
 
 - (void) render {
-  struct metil_scene_controller* metil_scene_controller = (
-    self->metil->scene_controller
+  struct metil_scene_controller* metil_scene_controller = (    self->metil->scene_controller
   );
 
   struct metil_scene* metil_scene = &(
@@ -2293,6 +2356,24 @@ void metil_renderer_poll_object(
     }
   }
 }
+
+#if target_os_ios
+void* _Nullable metil_renderer_thread_draw(
+  void* reference
+) {
+  MTKView*
+metal_kit_view = (    reference
+  );
+  [
+    metal_kit_view
+    draw
+  ];
+
+  return (
+    0x00
+  );
+}
+#endif
 
 void* metil_renderer_thread_poll_object(
   void* data

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1961,7 +1961,8 @@
 }
 
 - (void) render {
-  struct metil_scene_controller* metil_scene_controller = (    self->metil->scene_controller
+  struct metil_scene_controller* metil_scene_controller = (
+    self->metil->scene_controller
   );
 
   struct metil_scene* metil_scene = &(
@@ -2361,9 +2362,9 @@ void metil_renderer_poll_object(
 void* _Nullable metil_renderer_thread_draw(
   void* reference
 ) {
-  MTKView*
-metal_kit_view = (    reference
+  MTKView* metal_kit_view = (    reference
   );
+
   [
     metal_kit_view
     draw


### PR DESCRIPTION
- `metil_renderer`
- - ios
- - - prevent rendering when app is in the background
- - - reduces scene polling to 10fps when app is in the background