### PR TITLE
[enh] Metil editor source exports with pathing

### DIFF
--- a/tools/metil_editor/include/metil_editor_paths.h
+++ b/tools/metil_editor/include/metil_editor_paths.h
@@ -1,0 +1,11 @@
+#ifndef __metil_tools_metil_editor_metil_editor_paths_h
+#define __metil_tools_metil_editor_metil_editor_paths_h
+
+void metil_editor_paths_parse(
+  char*,
+  char**,
+  char**,
+  char**,
+  char**
+);
+#endif

--- a/tools/metil_editor/include/metil_editor_scene_data.h
+++ b/tools/metil_editor/include/metil_editor_scene_data.h
@@ -12,7 +12,11 @@ struct metil_editor_scene_data {
 
   unsigned char mode;
 
+  char* name_export;
+
   char* path_export;
+  char* path_export_c;
+  char* path_export_h;
 };
 
 #endif

--- a/tools/metil_editor/readme.md
+++ b/tools/metil_editor/readme.md
@@ -18,7 +18,9 @@ metil_editor [?path_to_import_and_or_export]
 | `period` | add vertex |
 | `slash` | add index (index value of closest vertex index) |
 | `command`+`s` | export file (exports to first parameter provided to `metil_editor`) |
+| `command`+`shift`+`s` | export mesh source files (`%.c`\|`%.h`) |
 | `g`+`[xyz]` | toggle grid axis visibility |
 
 ## copyright|copyleft
+
 > © [copyright|copyleft]:alic3dev(2026)->{all_lefts_reserved|all_rights_reserved};

--- a/tools/metil_editor/sources/metil_editor_paths.c
+++ b/tools/metil_editor/sources/metil_editor_paths.c
@@ -1,0 +1,250 @@
+#include <metil_editor_paths.h>
+
+#include <clic3_bytes.h>
+#include <clic3_char_arrays.h>
+#include <clic3_memory.h>
+
+#include <stdio.h>
+
+void metil_editor_paths_parse(
+  char* path,
+  char** name,
+  char** path_metil_mesh,
+  char** path_c,
+  char** path_h
+) {
+  unsigned int length_path = (
+    clic3_char_array_length(
+      path
+    )
+  );
+
+  unsigned int index_extension = (
+    0x00
+  );
+
+  unsigned int index_slash = (
+    0x00
+  );
+
+  unsigned char status = (
+    0b00000000
+  );
+
+  for (
+    unsigned int index_character = (
+      0x00
+    );
+    (
+      index_character <
+      length_path
+    );
+    ++index_character
+  ) {
+    unsigned int index_character_path = (
+      length_path -
+      index_character -
+      0x01
+    );
+
+    char character = (
+      path[
+        index_character_path
+      ]
+    );
+
+    switch (
+      character
+    ) {
+      case '.': {
+        if (
+          (
+            status &
+            0b11000000
+          ) !=
+          0x00
+        ) {
+          break;
+        }
+
+        if (
+          clic3_char_arrays_equal(
+            (
+              path +
+              index_character_path
+            ),
+            ".metil_mesh"
+          )
+        ) {
+          status = (
+            status |
+            0b11000000
+          );
+
+          index_extension = (
+            index_character_path
+          );
+        } else {
+          status = (
+            status |
+            0b01000000
+          );
+        }
+
+        break;
+      }
+      case '/': {
+        index_slash = (
+          index_character_path
+        );
+
+        status = (
+          status |
+          0b00000001
+        );
+
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    if (
+      (
+        status &
+        0b00000001
+      ) !=
+      0x00
+    ) {
+      break;
+    }
+  }
+
+  unsigned int length_name = (
+    length_path -
+    index_slash -
+    (
+      status &
+      0b00000001
+    ) -
+    (
+      (
+        (
+          status &
+          0b10000000
+        ) ==
+        0x00
+      )
+      ? 0x00
+      : (
+        length_path -
+        index_extension
+      )
+    )
+  );
+
+  *name = (
+    clic3_memory_allocate_raw(
+      length_name +
+      0x01
+    )
+  );
+
+  clic3_bytes_copy(
+    *name,
+    (
+      path +
+      length_path -
+      length_name +
+      (
+        status &
+        0b00000001
+      ) -
+
+      (
+        (
+          (
+            status &
+            0b10000000
+          ) ==
+          0x00
+        )
+        ? 0x00
+        : (
+          length_path -
+          index_extension
+        )
+      ) -
+      0x01
+    ),
+    length_name
+  );
+
+  (*name)[
+    length_name
+  ] = (
+    '\0'
+  );
+
+  if (
+    (
+      status &
+      0b10000000
+    ) ==
+    0x00
+  ) {
+    *path_metil_mesh = (
+      clic3_char_arrays_concatenate(
+        *name,
+        ".metil_mesh"
+      )
+    );
+  } else {
+    unsigned int length_path_metil_mesh = (
+      length_path -
+      index_slash -
+      (
+        status &
+        0b00000001
+      )
+    );
+
+    *path_metil_mesh = (
+      clic3_memory_allocate_raw(
+        length_path_metil_mesh +
+        0x01
+      )
+    );
+
+    clic3_bytes_copy(
+      *path_metil_mesh,
+      (
+        path +
+        length_path -
+        length_path_metil_mesh
+      ),
+      length_path_metil_mesh
+    );
+
+    (*path_metil_mesh)[
+      length_path_metil_mesh
+    ] = (
+      '\0'
+    );
+  }
+
+  *path_c = (
+    clic3_char_arrays_concatenate(
+      *name,
+      ".c"
+    )
+  );
+
+  *path_h = (
+    clic3_char_arrays_concatenate(
+      *name,
+      ".h"
+    )
+  );
+}

--- a/tools/metil_editor/sources/metil_editor_paths.c
+++ b/tools/metil_editor/sources/metil_editor_paths.c
@@ -187,6 +187,42 @@ void metil_editor_paths_parse(
     '\0'
   );
 
+  unsigned int length_path_without_extension = (
+    length_path -
+    (
+      (
+        (
+          status &
+          0b10000000
+        ) ==
+        0x00
+      )
+      ? 0x00
+      : (
+        length_path -
+        index_extension
+      )
+    )
+  );
+
+  char* path_without_extension = (
+    clic3_memory_allocate_raw(
+      length_path_without_extension +
+      0x01
+    )  );
+
+  clic3_bytes_copy(
+    path_without_extension,
+    path,
+    length_path_without_extension
+  );
+
+  path_without_extension[
+    length_path_without_extension
+  ] = (
+    '\0'
+  );
+
   if (
     (
       status &
@@ -196,18 +232,13 @@ void metil_editor_paths_parse(
   ) {
     *path_metil_mesh = (
       clic3_char_arrays_concatenate(
-        *name,
-        ".metil_mesh"
+        path,
+        ""
       )
     );
   } else {
     unsigned int length_path_metil_mesh = (
-      length_path -
-      index_slash -
-      (
-        status &
-        0b00000001
-      )
+      length_path
     );
 
     *path_metil_mesh = (
@@ -236,15 +267,19 @@ void metil_editor_paths_parse(
 
   *path_c = (
     clic3_char_arrays_concatenate(
-      *name,
+      path_without_extension,
       ".c"
     )
   );
 
   *path_h = (
     clic3_char_arrays_concatenate(
-      *name,
+      path_without_extension,
       ".h"
     )
+  );
+
+  clic3_memory_free_raw(
+    path_without_extension
   );
 }

--- a/tools/metil_editor/sources/metil_editor_scene.m
+++ b/tools/metil_editor/sources/metil_editor_scene.m
@@ -1,6 +1,7 @@
 #include <metil_editor_scene.h>
 
 #include <metil_editor_index_pipeline_render.h>
+#include <metil_editor_paths.h>
 #include <metil_editor_scene_data.h>
 
 #include <clic3_bytes.h>
@@ -55,17 +56,36 @@ void metil_editor_scene_initialize(
     metil->parameters.length_parameters >=
     0x02
   ) {
-    metil_editor_scene_data->path_export = (
-      (char*)
-      metil->parameters.parameters[
-        0x01
-      ]
+    metil_editor_paths_parse(
+      (
+        (char*)
+        metil->parameters.parameters[
+          0x01
+        ]
+      ),
+      &metil_editor_scene_data->name_export,
+      &metil_editor_scene_data->path_export,
+      &metil_editor_scene_data->path_export_c,
+      &metil_editor_scene_data->path_export_h
     );
   } else {
+    metil_editor_scene_data->name_export = (
+      0x00
+    );
+
     metil_editor_scene_data->path_export = (
       0x00
     );
+
+    metil_editor_scene_data->path_export_c = (
+      0x00
+    );
+
+    metil_editor_scene_data->path_export_h = (
+      0x00
+    );
   }
+
   metil_scene->poll = (
     metil_editor_scene_poll
   );
@@ -888,16 +908,44 @@ void metil_editor_scene_poll(
         );
       }
 
-      metil_mesh_export_raw(
-        length_indices,
-        metil_object_lines->mesh.length_vertices,
-        indices,
-        metil_object_lines->buffers_vertex[
-          metil_object_buffer_default_index_vertices
-        ].buffer.contents,
-        &metil_object_lines->mesh.size,
-        metil_editor_scene_data->path_export
-      );
+      if (
+        (
+          metil->input.keydown_map[
+            metil_keycode_shift_left
+          ] !=
+          0x00
+        ) ||
+        (
+          metil->input.keydown_map[
+            metil_keycode_shift_right
+          ] !=
+          0x00
+        )
+      ) {
+        metil_mesh_export_source_raw(
+          length_indices,
+          metil_object_lines->mesh.length_vertices,
+          indices,
+          metil_object_lines->buffers_vertex[
+            metil_object_buffer_default_index_vertices
+          ].buffer.contents,
+          &metil_object_lines->mesh.size,
+          metil_editor_scene_data->name_export,
+          metil_editor_scene_data->path_export_c,
+          metil_editor_scene_data->path_export_h
+        );
+      } else {
+        metil_mesh_export_raw(
+          length_indices,
+          metil_object_lines->mesh.length_vertices,
+          indices,
+          metil_object_lines->buffers_vertex[
+            metil_object_buffer_default_index_vertices
+          ].buffer.contents,
+          &metil_object_lines->mesh.size,
+          metil_editor_scene_data->path_export
+        );
+      }
 
       metil->input.keydown_map[
         metil_keycode_s
@@ -1346,6 +1394,26 @@ void metil_editor_scene_destroy(
   struct metil* metil,
   struct metil_scene* metil_scene
 ) {
+  struct metil_editor_scene_data* metil_editor_scene_data = (
+    metil_scene->data
+  );
+
+  clic3_memory_free(
+    metil_editor_scene_data->name_export
+  );
+
+  clic3_memory_free(
+    metil_editor_scene_data->path_export
+  );
+
+  clic3_memory_free(
+    metil_editor_scene_data->path_export_c
+  );
+
+  clic3_memory_free(
+    metil_editor_scene_data->path_export_h
+  );
+
   struct metil_object* metil_object_points = (
     metil_scene->renderables[
       metil_editor_scene_index_renderable_points


### PR DESCRIPTION
- `metil_editor`
- - add source exports
- `metil_editor_paths`:add
- - parses input parameter into
- - - `name`: name without `.metil_mesh`
- - - `path_metil_mesh`: `name` + `.metil_mesh`
- - - `path_c`: `name` + `.c`
- - - `path_h`: `name` + `.h`