### PR TITLE
[enh] `page_landing`:metil_release_2.0.0::add

### DIFF
--- a/page_landing/index.html
+++ b/page_landing/index.html
@@ -109,6 +109,58 @@ sss<html
     <ul>
       <li>
         <a
+          href="https://github.com/alic3dev/metil/releases/tag/release_version-%3E%7B2.0.0%7D%3B"
+        >
+          metil::version->{2.0.0};
+        </a>
+        
+        <ul>
+          <li>
+            <a
+              href="https://github.com/alic3dev/metil/releases/download/release_version-%3E%7B2.0.0%7D%3B/metil_include.2.0.0.tar.gz"
+            >
+              metil_include.2.0.0.tar.gz
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/alic3dev/metil/releases/download/release_version-%3E%7B2.0.0%7D%3B/metil_library.2.0.0.tar.gz"
+            >
+              metil_library.2.0.0.tar.gz
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/alic3dev/metil/releases/download/release_version-%3E%7B2.0.0%7D%3B/metil_library_ios.2.0.0.tar.gz"
+            >
+              metil_library_ios.2.0.0.tar.gz
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/alic3dev/metil/releases/download/release_version-%3E%7B2.0.0%7D%3B/metil_examples.2.0.0.tar.gz"
+            >
+              metil_examples.2.0.0.tar.gz
+            </a>
+          </li>
+          <li>
+            <a
+              href="https://github.com/alic3dev/metil/archive/refs/tags/release_version-%3E%7B2.0.0%7D;.zip"
+            >
+              metil_code_source.2.0.0.zip
+            </a>
+            |
+            <a
+              href="https://github.com/alic3dev/metil/archive/refs/tags/release_version-%3E%7B2.0.0%7D;.tar.gz"
+            >
+              metil_code_source.2.0.0.tar.gz
+            </a>
+          </li>
+        </ul>
+      </li>
+    
+      <li>
+        <a
           href="https://github.com/alic3dev/metil/releases/tag/release_version->%7B1.0.0%7D%3B"
         >
           metil::version->{1.0.0};


### PR DESCRIPTION
- `page_landing`:
- - add->{metil_release::2.0.0};

<img width="483" height="382" alt="Screenshot 2026-05-31 at 18 01 59" src="https://github.com/user-attachments/assets/b3b3e30d-e516-48c4-b79b-162f20351ae0" />
