### PR TITLE
[enh] `metil_texture_store`:implement

### DIFF
--- a/include/metil.h
+++ b/include/metil.h
@@ -16,6 +16,7 @@
 #include <metil_termination/metil_termination.h>
 #include <metil_text/metil_text_characters.h>
 #include <metil_text/metil_text_defaults.h>
+#include <metil_texture_store.h>
 
 struct metil;
 
@@ -40,6 +41,8 @@ struct metil {
   struct metil_player_defaults player_defaults;
   struct metil_text_characters text_characters_default;
   struct metil_text_defaults text_defaults;
+  
+  struct metil_texture_store texture_store;
 
   void* _Nullable data;
 

--- a/include/metil_texture_store.h
+++ b/include/metil_texture_store.h
@@ -1,0 +1,38 @@
+#ifndef __metil_metil_texture_store_h
+#define __metil_metil_texture_store_h
+
+#include <metil_debug/metil_debug_log_level.h>
+
+#include <Metal/MTLDevice.h>
+#include <Metal/MTLTexture.h>
+#include <MetalKit/MTKTextureLoader.h>
+
+struct metil_texture_store {
+  id<MTLTexture>* textures;
+  unsigned int length_textures;
+  
+  MTKTextureLoader* loader;
+  
+  char* path_directory_textures;
+  
+  enum metil_debug_log_level* debug_log_level;
+};
+
+void metil_texture_store_initialize(
+  struct metil_texture_store*,
+  char*,
+  enum metil_debug_log_level*,
+  id<MTLDevice>
+);
+
+void metil_texture_store_add(
+  struct metil_texture_store*,
+  unsigned int length_texturs,
+  ...
+);
+
+void metil_texture_store_destroy(
+  struct metil_texture_store*
+);
+
+#endif

--- a/sources/metil.m
+++ b/sources/metil.m
@@ -8,6 +8,7 @@
 #include <metil_rendering/metil_renderer.h>
 #include <metil_scenes/metil_scene_controller.h>
 #include <metil_text/metil_text.h>
+#include <metil_texture_store.h>
 
 #include <clic3_memory.h>
 
@@ -91,6 +92,10 @@ void metil_destroy(
 
   metil_parameters_destroy(
     &metil->parameters
+  );
+  
+  metil_texture_store_destroy(
+    &metil->texture_store
   );
 
   if (

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -19,6 +19,7 @@
 #include <metil_termination/metil_terminate_on_signal.h>
 #include <metil_text/metil_text.h>
 #include <metil_text/metil_text_defaults.h>
+#include <metil_texture_store.h>
 #include <metil_utilities/metil_time.h>
 
 #include <clic3_char_arrays.h>
@@ -145,6 +146,7 @@ int metil_initialize_with_parameters_with_data(
   metil.renderer_on_initialize = (
     metil_renderer_on_initialize_function
   );
+  
   metil.renderer_on_initialize_data = (
     metil_renderer_on_initialize_function_data
   );

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -187,6 +187,13 @@
     self
     descriptor_pipeline_render_initialize
   ];
+  
+  metil_texture_store_initialize(
+    &metil->texture_store,
+    metil->paths.directory_textures,
+    &metil->configuration.debug_log_level,
+    metil->renderer_interface.metal_device
+  );
 
   if (
     self->metil->renderer_on_initialize !=

--- a/sources/metil_texture_store.m
+++ b/sources/metil_texture_store.m
@@ -1,9 +1,203 @@
-// #include <metil_textures.h>
+#include <metil_texture_store.h>
 
-void metil_texture_store_initialize() {
+#include <clic3_memory.h>
 
+#include <metil_debug/metil_debug_log.h>
+
+#include <Metal/MTLTexture.h>
+#include <MetalKit/MTKTextureLoader.h>
+
+#include <stdarg.h>
+#include <stdio.h>
+
+void metil_texture_store_initialize(
+  struct metil_texture_store* metil_texture_store,
+  char* path_directory_textures,
+  enum metil_debug_log_level* metil_debug_log_level,
+  id<MTLDevice> metal_device
+) {
+  metil_texture_store->length_textures = (
+    0x00
+  );
+  
+  metil_texture_store->textures = (
+    clic3_memory_allocate_raw(
+      0x00
+    )
+  );
+  
+  metil_texture_store->loader = [
+    [
+      MTKTextureLoader
+      alloc
+    ]
+    initWithDevice: (
+      metal_device
+    )
+  ];
+  
+  metil_texture_store->path_directory_textures = (
+    path_directory_textures
+  );
+  
+  metil_texture_store->debug_log_level = (
+    metil_debug_log_level
+  );  
 }
 
-void metil_texture_store_destroy() {
+void metil_texture_store_add(
+  struct metil_texture_store* metil_texture_store,
+  unsigned int length_textures,
+  ...
+) {
+  unsigned int offset_texture = (
+    metil_texture_store->length_textures
+  );
 
+  metil_texture_store->length_textures = (
+    metil_texture_store->length_textures +
+    length_textures
+  );
+  
+  clic3_memory_reallocate_raw(
+    &metil_texture_store->textures,
+    (
+      sizeof(
+        id<MTLTexture>
+      ) *
+      metil_texture_store->length_textures
+    )
+  );
+
+  va_list textures;
+  
+  va_start(
+    textures,
+    length_textures
+  );
+  
+  char* texture_path;
+  
+  for (
+    unsigned int index_texture = (
+      0x00
+    );
+    (
+      index_texture <
+      length_textures
+    );
+    ++index_texture
+  ) {
+    texture_path = (
+      va_arg(
+        textures,
+        char*
+      )
+    );
+    
+    NSError* error = (
+      0x00
+    );
+    
+    NSString* texture_path_string = [
+      [
+        NSString
+        alloc
+      ]
+      initWithUTF8String: (
+        texture_path
+      )
+    ]; 
+    
+    id<MTLTexture> texture = [
+      metil_texture_store->loader
+      newTextureWithContentsOfURL: [
+        NSURL
+        fileURLWithPath: (
+          texture_path_string
+        )
+        isDirectory: (
+          0x00
+        )
+        relativeToURL: [
+          NSURL
+          fileURLWithPath:[
+            NSString
+            stringWithUTF8String: (
+              metil_texture_store->path_directory_textures
+            )
+          ]
+          isDirectory: (
+            0x01
+          )
+        ]
+      ]
+      options: (
+        0x00
+      )
+      error: &(
+        error
+      )
+    ];
+    
+    [
+      texture_path_string
+      release
+    ];
+    
+    if (
+      error !=
+      0x00
+    ) {
+      metil_texture_store->textures[
+        offset_texture +
+        index_texture
+      ] = (
+        0x00
+      );
+      
+      metil_debug_log_error(
+        *metil_texture_store->debug_log_level,
+        "failed_to_load_texture"
+      );
+    } else {
+      metil_texture_store->textures[
+        offset_texture +
+        index_texture
+      ] = (
+        texture
+      );
+    }
+  }  
+}
+
+void metil_texture_store_destroy(
+  struct metil_texture_store* metil_texture_store
+) {
+  for (
+    unsigned int index_texture = (
+      0x00
+    );
+    (
+      index_texture <
+      metil_texture_store->length_textures
+    );
+    ++index_texture
+  ) {
+    [
+      metil_texture_store->textures[
+        index_texture
+      ]
+      release
+    ];
+  }
+  
+  clic3_memory_free_raw(
+    metil_texture_store->textures
+  );
+  
+  [
+    metil_texture_store->loader
+    release
+  ];
 }


### PR DESCRIPTION
- `metil_texture_store`:implement
- - stores textures for the lifetime of the executable