### PR TITLE
[dev|enh] Metil paths foundation debug logging and texture store

### DIFF
--- a/include/metil.h
+++ b/include/metil.h
@@ -43,7 +43,7 @@ struct metil {
   struct metil_player_defaults player_defaults;
   struct metil_text_characters text_characters_default;
   struct metil_text_defaults text_defaults;
-  
+
   struct metil_texture_store texture_store;
 
   void* _Nullable data;

--- a/include/metil.h
+++ b/include/metil.h
@@ -8,6 +8,7 @@
 #include <metil_library.h>
 #include <metil_parameters.h>
 #include <metil_paths/metil_paths.h>
+#include <metil_paths/metil_paths_foundation.h>
 #include <metil_player/metil_player_defaults.h>
 #include <metil_rendering/metil_renderer_interface.h>
 #include <metil_rendering/metil_renderer_on_initialize.h>
@@ -32,6 +33,7 @@ struct metil {
   struct metil_library library;
   struct metil_parameters parameters;
   struct metil_paths paths;
+  struct metil_paths_foundation paths_foundation;
   struct metil_renderer_interface renderer_interface;
   struct metil_rendering_properties rendering_properties;
   void* _Nonnull scene_controller;

--- a/include/metil_debug/metil_debug_log.h
+++ b/include/metil_debug/metil_debug_log.h
@@ -3,14 +3,42 @@
 
 #include <metil_debug/metil_debug_log_level.h>
 
+#include <stdarg.h>
+#include <stdio.h>
+
 void metil_debug_log(
-  enum metil_debug_log_level,
+  unsigned char,
   char*
 );
 
+void metil_debug_log_parameters(
+  unsigned char,
+  char*,
+  unsigned int,
+  ...
+);
+
 void metil_debug_log_error(
-  enum metil_debug_log_level,
+  unsigned char,
   char*
+);
+
+void metil_debug_log_parameters_error(
+  unsigned char,
+  char*,
+  unsigned int,
+  ...
+);
+
+void metil_debug_log_print(
+  FILE*,
+  char*
+);
+
+void metil_debug_log_print_parameters(
+  FILE*,
+  char*,
+  va_list
 );
 
 #endif

--- a/include/metil_debug/metil_debug_log_level.h
+++ b/include/metil_debug/metil_debug_log_level.h
@@ -2,9 +2,10 @@
 #define __metil_debug_metil_debug_log_level_h
 
 enum metil_debug_log_level {
-  metil_debug_log_level_all = 1,
-  metil_debug_log_level_error = 2,
-  metil_debug_log_level_none = 0
+  metil_debug_log_level_none  = 0x00,
+  metil_debug_log_level_all   = 0x01,
+  metil_debug_log_level_info   = 0x02,
+  metil_debug_log_level_error = 0x03,
 };
 
 #endif

--- a/include/metil_mesh/metil_mesh_export.h
+++ b/include/metil_mesh/metil_mesh_export.h
@@ -37,6 +37,5 @@ metil_status metil_mesh_export_source_raw(
   char*,
   char*
 );
-  
 
 #endif

--- a/include/metil_paths/metil_paths_constants.h
+++ b/include/metil_paths/metil_paths_constants.h
@@ -1,13 +1,13 @@
 #ifndef __metil_paths_metil_paths_constants_h
 #define __metil_paths_metil_paths_constants_h
 
-#define metil_paths_length_directory_configuration 8
+#define metil_paths_length_directory_configuration 0x08
 #if target_os_ios
-#define metil_paths_length_directory_resources 2
+#define metil_paths_length_directory_resources 0x02
 #else
-#define metil_paths_length_directory_resources 13
+#define metil_paths_length_directory_resources 0x0d
 #endif
-#define metil_paths_length_directory_textures 9
+#define metil_paths_length_directory_textures 0x09
 
 #define metil_paths_directory_configuration ".config/"
 

--- a/include/metil_paths/metil_paths_foundation.h
+++ b/include/metil_paths/metil_paths_foundation.h
@@ -1,0 +1,23 @@
+#ifndef __metil_paths_metil_paths_foundation_h
+#define __metil_paths_metil_paths_foundation_h
+
+#include <metil_paths/metil_paths.h>
+
+#include <Foundation/NSURL.h>
+
+struct metil_paths_foundation {
+  NSString* _Nonnull string_directory_textures;
+
+  NSURL* _Nonnull url_directory_textures;
+};
+
+void metil_paths_foundation_initialize(
+  struct metil_paths_foundation* _Nonnull,
+  struct metil_paths* _Nonnull
+);
+
+void metil_paths_foundation_destroy(
+  struct metil_paths_foundation* _Nonnull
+);
+
+#endif

--- a/include/metil_texture_store.h
+++ b/include/metil_texture_store.h
@@ -12,11 +12,11 @@
 struct metil_texture_store {
   id<MTLTexture>* textures;
   unsigned int length_textures;
-  
+
   MTKTextureLoader* loader;
-  
+
   NSURL* url_directory_textures;
-  
+
   enum metil_debug_log_level* debug_log_level;
 };
 

--- a/include/metil_texture_store.h
+++ b/include/metil_texture_store.h
@@ -3,6 +3,8 @@
 
 #include <metil_debug/metil_debug_log_level.h>
 
+#include <Foundation/NSURL.h>
+
 #include <Metal/MTLDevice.h>
 #include <Metal/MTLTexture.h>
 #include <MetalKit/MTKTextureLoader.h>
@@ -13,14 +15,14 @@ struct metil_texture_store {
   
   MTKTextureLoader* loader;
   
-  char* path_directory_textures;
+  NSURL* url_directory_textures;
   
   enum metil_debug_log_level* debug_log_level;
 };
 
 void metil_texture_store_initialize(
   struct metil_texture_store*,
-  char*,
+  NSURL*,
   enum metil_debug_log_level*,
   id<MTLDevice>
 );

--- a/sources/metil.m
+++ b/sources/metil.m
@@ -4,6 +4,7 @@
 #include <metil_configuration/metil_configuration.h>
 #include <metil_parameters.h>
 #include <metil_paths/metil_paths.h>
+#include <metil_paths/metil_paths_foundation.h>
 #include <metil_player/metil_player_defaults.h>
 #include <metil_rendering/metil_renderer.h>
 #include <metil_scenes/metil_scene_controller.h>
@@ -70,6 +71,10 @@ void metil_destroy(
 
   metil_paths_destroy(
     &metil->paths
+  );
+  
+  metil_paths_foundation_destroy(
+    &metil->paths_foundation
   );
 
   if (

--- a/sources/metil.m
+++ b/sources/metil.m
@@ -72,7 +72,7 @@ void metil_destroy(
   metil_paths_destroy(
     &metil->paths
   );
-  
+
   metil_paths_foundation_destroy(
     &metil->paths_foundation
   );
@@ -98,7 +98,7 @@ void metil_destroy(
   metil_parameters_destroy(
     &metil->parameters
   );
-  
+
   metil_texture_store_destroy(
     &metil->texture_store
   );

--- a/sources/metil_debug/metil_log.c
+++ b/sources/metil_debug/metil_log.c
@@ -17,12 +17,12 @@ void metil_debug_log(
       return;
     }
   }
-  
+
   metil_debug_log_print(
     stdout,
     buffer_output
   );
-}  
+}
 
 void metil_debug_log_parameters(
   unsigned char metil_debug_log_level,
@@ -41,20 +41,20 @@ void metil_debug_log_parameters(
       return;
     }
   }
-  
+
   va_list parameters;
 
   va_start(
     parameters,
     length_parameters
   );
-  
+
   metil_debug_log_print_parameters(
     stdout,
     format,
     parameters
   );
-  
+
   va_end(
     parameters
   );
@@ -75,12 +75,12 @@ void metil_debug_log_error(
       return;
     }
   }
-  
+
   metil_debug_log_print(
     stdout,
     buffer_output
   );
-}  
+}
 
 void metil_debug_log_parameters_error(
   unsigned char metil_debug_log_level,
@@ -94,20 +94,20 @@ void metil_debug_log_parameters_error(
   ) {
     return;
   }
-  
+
   va_list parameters;
 
   va_start(
     parameters,
     length_parameters
   );
-  
+
   metil_debug_log_print_parameters(
     stderr,
     format,
     parameters
   );
-  
+
   va_end(
     parameters
   );
@@ -133,5 +133,5 @@ void metil_debug_log_print_parameters(
    stream_output,
    format,
    parameters
- ); 
+ );
 }

--- a/sources/metil_debug/metil_log.c
+++ b/sources/metil_debug/metil_log.c
@@ -1,37 +1,137 @@
 #include <metil_debug/metil_debug_log.h>
 
+#include <stdarg.h>
 #include <stdio.h>
 
 void metil_debug_log(
-  enum metil_debug_log_level metil_debug_log_level,
+  unsigned char metil_debug_log_level,
   char* buffer_output
 ) {
+  switch (
+    metil_debug_log_level
+  ) {
+    case metil_debug_log_level_all:
+    case metil_debug_log_level_info: {
+      break;    }
+    default: {
+      return;
+    }
+  }
+  
+  metil_debug_log_print(
+    stdout,
+    buffer_output
+  );
+}  
+
+void metil_debug_log_parameters(
+  unsigned char metil_debug_log_level,
+  char* format,
+  unsigned int length_parameters,
+  ...
+) {
+  switch (
+    metil_debug_log_level
+  ) {
+    case metil_debug_log_level_all:
+    case metil_debug_log_level_info:
+{      break;
+    }
+    default: {
+      return;
+    }
+  }
+  
+  va_list parameters;
+
+  va_start(
+    parameters,
+    length_parameters
+  );
+  
+  metil_debug_log_print_parameters(
+    stdout,
+    format,
+    parameters
+  );
+  
+  va_end(
+    parameters
+  );
+}
+
+void metil_debug_log_error(
+  unsigned char metil_debug_log_level,
+  char* buffer_output
+) {
+  switch (
+    metil_debug_log_level
+  ) {
+    case metil_debug_log_level_all:
+    case metil_debug_log_level_info: {
+      break;
+    }
+    default: {
+      return;
+    }
+  }
+  
+  metil_debug_log_print(
+    stdout,
+    buffer_output
+  );
+}  
+
+void metil_debug_log_parameters_error(
+  unsigned char metil_debug_log_level,
+  char* format,
+  unsigned int length_parameters,
+  ...
+) {
   if (
-    metil_debug_log_level != metil_debug_log_level_all
+    metil_debug_log_level ==
+    metil_debug_log_level_none
   ) {
     return;
   }
+  
+  va_list parameters;
 
+  va_start(
+    parameters,
+    length_parameters
+  );
+  
+  metil_debug_log_print_parameters(
+    stderr,
+    format,
+    parameters
+  );
+  
+  va_end(
+    parameters
+  );
+}
+
+void metil_debug_log_print(
+  FILE* stream_output,
+  char* buffer_output
+) {
   fprintf(
-    stdout,
+    stream_output,
     "%s",
     buffer_output
   );
 }
 
-void metil_debug_log_error(
-  enum metil_debug_log_level metil_debug_log_level,
-  char* buffer_output
+void metil_debug_log_print_parameters(
+  FILE* stream_output,
+  char* format,
+  va_list parameters
 ) {
-  if (
-    metil_debug_log_level == metil_debug_log_level_none
-  ) {
-    return;
-  }
-
-  fprintf(
-    stderr,
-    "%s",
-    buffer_output
-  );
+ vfprintf(
+   stream_output,
+   format,
+   parameters
+ ); 
 }

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -146,7 +146,7 @@ int metil_initialize_with_parameters_with_data(
   metil.renderer_on_initialize = (
     metil_renderer_on_initialize_function
   );
-  
+
   metil.renderer_on_initialize_data = (
     metil_renderer_on_initialize_function_data
   );
@@ -161,7 +161,7 @@ int metil_initialize_with_parameters_with_data(
     ),
     name
   );
-  
+
   metil_paths_foundation_initialize(
     &metil.paths_foundation,
     &metil.paths

--- a/sources/metil_initialize.m
+++ b/sources/metil_initialize.m
@@ -161,6 +161,11 @@ int metil_initialize_with_parameters_with_data(
     ),
     name
   );
+  
+  metil_paths_foundation_initialize(
+    &metil.paths_foundation,
+    &metil.paths
+  );
 
   #if target_os_ios
   metil_configuration_initialize(

--- a/sources/metil_mesh/metil_mesh_export.c
+++ b/sources/metil_mesh/metil_mesh_export.c
@@ -258,7 +258,7 @@ metil_status metil_mesh_export_source_raw(
   struct math_c_vector3_float* size,
   char* name_mesh,
   char* path_file_export_c,
-  char* path_file_export_h  
+  char* path_file_export_h
 ) {
   FILE* file_export_c = (
     fopen(
@@ -266,7 +266,7 @@ metil_status metil_mesh_export_source_raw(
       "wb"
     )
   );
-  
+
   if (
     file_export_c ==
     0x00
@@ -275,14 +275,14 @@ metil_status metil_mesh_export_source_raw(
       metil_status_error
     );
   }
-  
+
   FILE* file_export_h = (
     fopen(
       path_file_export_h,
       "wb"
     )
   );
-  
+
   if (
     file_export_h ==
     0x00
@@ -290,7 +290,7 @@ metil_status metil_mesh_export_source_raw(
     fclose(
       file_export_c
     );
-    
+
     return (
       metil_status_error
     );
@@ -336,7 +336,7 @@ metil_status metil_mesh_export_source_raw(
     name_mesh,
     size->z
   );
-  
+
   for (
     unsigned int index_vertex = (
       0x00
@@ -395,7 +395,7 @@ metil_status metil_mesh_export_source_raw(
       ].w
     );
   }
-  
+
   for (
     unsigned int index_index = (
       0x00
@@ -421,7 +421,7 @@ metil_status metil_mesh_export_source_raw(
       ]
     );
   }
-  
+
   fprintf(
     file_export_c,
     "}\n"
@@ -448,11 +448,11 @@ metil_status metil_mesh_export_source_raw(
   fclose(
     file_export_c
   );
-  
+
   fclose(
     file_export_h
   );
-      
+
   return (
     metil_status_success
   );

--- a/sources/metil_paths/metil_paths.c
+++ b/sources/metil_paths/metil_paths.c
@@ -15,7 +15,7 @@ void metil_paths_initialize(
   metil_paths->length_directory_root = (
     0x00
   );
-  
+
   metil_paths->length_directory_home = (
     0x00
   );
@@ -23,11 +23,11 @@ void metil_paths_initialize(
   metil_paths->length_directory_configuration = (
     0x00
   );
-  
+
   metil_paths->length_directory_resources = (
     0x00
   );
-  
+
   metil_paths->length_directory_textures = (
     0x00
   );
@@ -109,13 +109,13 @@ void metil_paths_directory_root_set(
     ] = (
       '.'
     );
-    
+
     metil_paths->directory_root[
       0x01
     ] = (
       '/'
     );
-    
+
     metil_paths->directory_root[
       0x02
     ] = (

--- a/sources/metil_paths/metil_paths.c
+++ b/sources/metil_paths/metil_paths.c
@@ -12,14 +12,29 @@ void metil_paths_initialize(
   char* directory_root,
   char* file_configuration
 ) {
-  metil_paths->length_directory_root = 0;
-  metil_paths->length_directory_home = 0;
+  metil_paths->length_directory_root = (
+    0x00
+  );
+  
+  metil_paths->length_directory_home = (
+    0x00
+  );
 
-  metil_paths->length_directory_configuration = 0;
-  metil_paths->length_directory_resources = 0;
-  metil_paths->length_directory_textures = 0;
+  metil_paths->length_directory_configuration = (
+    0x00
+  );
+  
+  metil_paths->length_directory_resources = (
+    0x00
+  );
+  
+  metil_paths->length_directory_textures = (
+    0x00
+  );
 
-  metil_paths->length_file_configuration = 0;
+  metil_paths->length_file_configuration = (
+    0x00
+  );
 
   metil_paths_directory_root_set(
     metil_paths,
@@ -48,30 +63,40 @@ void metil_paths_directory_root_set(
   struct metil_paths* metil_paths,
   char* directory_root
 ) {
-  unsigned int index_slash = 0;
+  unsigned int index_slash = (
+    0x00
+  );
 
   while (
     directory_root[
       metil_paths->length_directory_root
-    ] != '\0'
+    ] !=
+    '\0'
   ) {
     if (
       directory_root[
         metil_paths->length_directory_root
-      ] == '/'
+      ] ==
+      '/'
     ) {
-      index_slash = metil_paths->length_directory_root;
+      index_slash = (
+        metil_paths->length_directory_root
+      );
     }
 
     metil_paths->length_directory_root = (
-      metil_paths->length_directory_root + 1
+      metil_paths->length_directory_root +
+      0x01
     );
   }
 
   if (
-    index_slash < 2
+    index_slash <
+    0x02
   ) {
-    metil_paths->length_directory_root = 3;
+    metil_paths->length_directory_root = (
+      0x03
+    );
 
     metil_paths->directory_root = (
       clic3_memory_allocate_raw(
@@ -79,11 +104,28 @@ void metil_paths_directory_root_set(
       )
     );
 
-    metil_paths->directory_root[0] = '.';
-    metil_paths->directory_root[1] = '/';
-    metil_paths->directory_root[2] = '\0';
+    metil_paths->directory_root[
+      0x00
+    ] = (
+      '.'
+    );
+    
+    metil_paths->directory_root[
+      0x01
+    ] = (
+      '/'
+    );
+    
+    metil_paths->directory_root[
+      0x02
+    ] = (
+      '\0'
+    );
   } else {
-    metil_paths->length_directory_root = index_slash + 2;
+    metil_paths->length_directory_root = (
+      index_slash +
+      0x02
+    );
 
     metil_paths->directory_root = (
       clic3_memory_allocate_raw(
@@ -94,12 +136,18 @@ void metil_paths_directory_root_set(
     clic3_bytes_copy(
       metil_paths->directory_root,
       directory_root,
-      metil_paths->length_directory_root - 1
+      (
+        metil_paths->length_directory_root -
+        0x01
+      )
     );
 
     metil_paths->directory_root[
-      metil_paths->length_directory_root - 1
-    ] = '\0';
+      metil_paths->length_directory_root -
+      0x01
+    ] = (
+      '\0'
+    );
   }
 }
 
@@ -108,7 +156,9 @@ void metil_paths_directory_home_set(
 ) {
   metil_paths->directory_home = (
     clic3_char_arrays_concatenate(
-      getenv("HOME"),
+      getenv(
+        "HOME"
+      ),
       "/"
     )
   );

--- a/sources/metil_paths/metil_paths_foundation.m
+++ b/sources/metil_paths/metil_paths_foundation.m
@@ -1,0 +1,51 @@
+#include <metil_paths/metil_paths_foundation.h>
+
+#include <metil_paths/metil_paths.h>
+
+void metil_paths_foundation_initialize(
+  struct metil_paths_foundation* metil_paths_foundation,
+  struct metil_paths* metil_paths
+) {
+  metil_paths_foundation->string_directory_textures = [
+    [
+      NSString
+      alloc
+    ]
+    initWithUTF8String: (
+      metil_paths->directory_textures
+    )
+  ];    
+  metil_paths_foundation->url_directory_textures = [
+    NSURL
+    fileURLWithPath: (
+      metil_paths_foundation->string_directory_textures
+    )
+    isDirectory: (
+      0x01
+    )
+  ]; 
+  
+  [
+    metil_paths_foundation->string_directory_textures
+    retain
+  ];
+  
+  [
+    metil_paths_foundation->url_directory_textures
+    retain
+  ]; 
+}
+
+void metil_paths_foundation_destroy(
+  struct metil_paths_foundation* metil_paths_foundation
+) {
+  [
+    metil_paths_foundation->string_directory_textures
+    release
+  ];
+  
+  [
+    metil_paths_foundation->url_directory_textures
+    release
+  ];
+}

--- a/sources/metil_paths/metil_paths_foundation.m
+++ b/sources/metil_paths/metil_paths_foundation.m
@@ -14,7 +14,7 @@ void metil_paths_foundation_initialize(
     initWithUTF8String: (
       metil_paths->directory_textures
     )
-  ];    
+  ];
   metil_paths_foundation->url_directory_textures = [
     NSURL
     fileURLWithPath: (
@@ -23,17 +23,17 @@ void metil_paths_foundation_initialize(
     isDirectory: (
       0x01
     )
-  ]; 
-  
+  ];
+
   [
     metil_paths_foundation->string_directory_textures
     retain
   ];
-  
+
   [
     metil_paths_foundation->url_directory_textures
     retain
-  ]; 
+  ];
 }
 
 void metil_paths_foundation_destroy(
@@ -43,7 +43,7 @@ void metil_paths_foundation_destroy(
     metil_paths_foundation->string_directory_textures
     release
   ];
-  
+
   [
     metil_paths_foundation->url_directory_textures
     release

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -190,7 +190,7 @@
   
   metil_texture_store_initialize(
     &metil->texture_store,
-    metil->paths.directory_textures,
+    metil->paths_foundation.url_directory_textures,
     &metil->configuration.debug_log_level,
     metil->renderer_interface.metal_device
   );

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -187,7 +187,7 @@
     self
     descriptor_pipeline_render_initialize
   ];
-  
+
   metil_texture_store_initialize(
     &metil->texture_store,
     metil->paths_foundation.url_directory_textures,

--- a/sources/metil_scenes/metil_scene_controller.m
+++ b/sources/metil_scenes/metil_scene_controller.m
@@ -14,7 +14,7 @@ void metil_scene_controller_initialize(
   metil_scene_controller->length_on_scene_change = (
     0x00
   );
-  
+
   metil_scene_controller->length_after_scene_change = (
     0x00
   );

--- a/sources/metil_scenes/metil_scene_controller.m
+++ b/sources/metil_scenes/metil_scene_controller.m
@@ -11,8 +11,13 @@ void metil_scene_controller_initialize(
   struct metil* metil,
   struct metil_scene_controller* metil_scene_controller
 ) {
-  metil_scene_controller->length_on_scene_change = 0;
-  metil_scene_controller->length_after_scene_change = 0;
+  metil_scene_controller->length_on_scene_change = (
+    0x00
+  );
+  
+  metil_scene_controller->length_after_scene_change = (
+    0x00
+  );
 
   metil_scene_initialize(
     metil,
@@ -21,25 +26,25 @@ void metil_scene_controller_initialize(
 
   metil_scene_controller->on_scene_change = (
     clic3_memory_allocate_raw(
-      0
+      0x00
     )
   );
 
   metil_scene_controller->on_scene_change_data = (
     clic3_memory_allocate_raw(
-      0
+      0x00
     )
   );
 
   metil_scene_controller->after_scene_change = (
     clic3_memory_allocate_raw(
-      0
+      0x00
     )
   );
 
   metil_scene_controller->after_scene_change_data = (
     clic3_memory_allocate_raw(
-      0
+      0x00
     )
   );
 }
@@ -50,8 +55,13 @@ void metil_scene_controller_scene_change(
   int scene_id
 ) {
   for (
-    unsigned short int index_on_scene_change = 0;
-    index_on_scene_change < metil_scene_controller->length_on_scene_change;
+    unsigned short int index_on_scene_change = (
+      0x00
+    );
+    (
+      index_on_scene_change <
+      metil_scene_controller->length_on_scene_change
+    );
     ++index_on_scene_change
   ) {
     metil_scene_controller->on_scene_change[
@@ -66,8 +76,13 @@ void metil_scene_controller_scene_change(
   }
 
   for (
-    unsigned short int index_after_scene_change = 0;
-    index_after_scene_change < metil_scene_controller->length_after_scene_change;
+    unsigned short int index_after_scene_change = (
+      0x00
+    );
+    (
+      index_after_scene_change <
+      metil_scene_controller->length_after_scene_change
+    );
     ++index_after_scene_change
   ) {
     metil_scene_controller->after_scene_change[
@@ -89,7 +104,7 @@ void metil_scene_controller_on_scene_change_add(
 ) {
   metil_scene_controller->length_on_scene_change = (
     metil_scene_controller->length_on_scene_change +
-    1
+    0x01
   );
 
   clic3_memory_reallocate_raw(
@@ -113,12 +128,18 @@ void metil_scene_controller_on_scene_change_add(
   );
 
   metil_scene_controller->on_scene_change[
-    metil_scene_controller->length_on_scene_change - 1
-  ] = on_scene_change;
+    metil_scene_controller->length_on_scene_change -
+    0x01
+  ] = (
+    on_scene_change
+  );
 
   metil_scene_controller->on_scene_change_data[
-    metil_scene_controller->length_on_scene_change - 1
-  ] = on_scene_change_data;
+    metil_scene_controller->length_on_scene_change -
+    0x01
+  ] = (
+    on_scene_change_data
+  );
 }
 
 void metil_scene_controller_after_scene_change_add(
@@ -127,7 +148,8 @@ void metil_scene_controller_after_scene_change_add(
   void* after_scene_change_data
 ) {
   metil_scene_controller->length_after_scene_change = (
-    metil_scene_controller->length_after_scene_change + 1
+    metil_scene_controller->length_after_scene_change +
+    0x01
   );
 
   clic3_memory_reallocate_raw(
@@ -151,12 +173,18 @@ void metil_scene_controller_after_scene_change_add(
   );
 
   metil_scene_controller->after_scene_change[
-    metil_scene_controller->length_after_scene_change - 1
-  ] = after_scene_change;
+    metil_scene_controller->length_after_scene_change -
+    0x01
+  ] = (
+    after_scene_change
+  );
 
   metil_scene_controller->after_scene_change_data[
-    metil_scene_controller->length_after_scene_change - 1
-  ] = after_scene_change_data;
+    metil_scene_controller->length_after_scene_change -
+    0x01
+  ] = (
+    after_scene_change_data
+  );
 }
 
 void metil_scene_controller_destroy(

--- a/sources/metil_system_information.c
+++ b/sources/metil_system_information.c
@@ -10,7 +10,7 @@ void metil_system_information_initialize(
   struct metil_configuration* metil_configuration
 ) {
   unsigned int count_cores_cpu;
-  
+
   unsigned long length_count_cores_cpu = (
     sizeof(
       unsigned int

--- a/sources/metil_system_information.c
+++ b/sources/metil_system_information.c
@@ -10,28 +10,34 @@ void metil_system_information_initialize(
   struct metil_configuration* metil_configuration
 ) {
   unsigned int count_cores_cpu;
+  
   unsigned long length_count_cores_cpu = (
     sizeof(
       unsigned int
     )
   );
 
-  metil_system_information->cores_cpu = 1;
+  metil_system_information->cores_cpu = (
+    0x01
+  );
 
   int status_core_count = (
     sysctlbyname(
       "hw.ncpu",
       &count_cores_cpu,
       &length_count_cores_cpu,
-      0,
-      0
+      0x00,
+      0x00
     )
   );
 
   if (
-    status_core_count == 0
+    status_core_count ==
+    0x00
   ) {
-    metil_system_information->cores_cpu = count_cores_cpu;
+    metil_system_information->cores_cpu = (
+      count_cores_cpu
+    );
   } else {
     metil_debug_log_error(
       metil_configuration->debug_log_level,

--- a/sources/metil_texture_store.m
+++ b/sources/metil_texture_store.m
@@ -12,7 +12,7 @@
 
 void metil_texture_store_initialize(
   struct metil_texture_store* metil_texture_store,
-  char* path_directory_textures,
+  NSURL* url_directory_textures,
   enum metil_debug_log_level* metil_debug_log_level,
   id<MTLDevice> metal_device
 ) {
@@ -36,8 +36,8 @@ void metil_texture_store_initialize(
     )
   ];
   
-  metil_texture_store->path_directory_textures = (
-    path_directory_textures
+  metil_texture_store->url_directory_textures = (
+    url_directory_textures
   );
   
   metil_texture_store->debug_log_level = (
@@ -107,31 +107,31 @@ void metil_texture_store_add(
       initWithUTF8String: (
         texture_path
       )
+    ];
+    
+    NSURL* url_texture = [
+      NSURL
+      fileURLWithPath: (
+        texture_path_string
+      )
+      isDirectory: (
+        0x00
+      )
+      relativeToURL: (
+        metil_texture_store->url_directory_textures
+      )
+    ];
+    
+    [
+      url_texture
+      retain
     ]; 
     
     id<MTLTexture> texture = [
       metil_texture_store->loader
-      newTextureWithContentsOfURL: [
-        NSURL
-        fileURLWithPath: (
-          texture_path_string
-        )
-        isDirectory: (
-          0x00
-        )
-        relativeToURL: [
-          NSURL
-          fileURLWithPath:[
-            NSString
-            stringWithUTF8String: (
-              metil_texture_store->path_directory_textures
-            )
-          ]
-          isDirectory: (
-            0x01
-          )
-        ]
-      ]
+      newTextureWithContentsOfURL: (
+        url_texture
+      )
       options: (
         0x00
       )
@@ -156,9 +156,17 @@ void metil_texture_store_add(
         0x00
       );
       
-      metil_debug_log_error(
+      NSString* string_url = (
+        url_texture.path
+      );
+                  metil_debug_log_parameters_error(
         *metil_texture_store->debug_log_level,
-        "failed_to_load_texture"
+        "failed_to_load_texture->{%s}\n",
+        0x01,
+        [
+          string_url
+          UTF8String
+        ]
       );
     } else {
       metil_texture_store->textures[
@@ -168,6 +176,11 @@ void metil_texture_store_add(
         texture
       );
     }
+    
+    [
+      url_texture
+      release
+    ];
   }
   
   va_end(

--- a/sources/metil_texture_store.m
+++ b/sources/metil_texture_store.m
@@ -19,13 +19,13 @@ void metil_texture_store_initialize(
   metil_texture_store->length_textures = (
     0x00
   );
-  
+
   metil_texture_store->textures = (
     clic3_memory_allocate_raw(
       0x00
     )
   );
-  
+
   metil_texture_store->loader = [
     [
       MTKTextureLoader
@@ -35,14 +35,14 @@ void metil_texture_store_initialize(
       metal_device
     )
   ];
-  
+
   metil_texture_store->url_directory_textures = (
     url_directory_textures
   );
-  
+
   metil_texture_store->debug_log_level = (
     metil_debug_log_level
-  );  
+  );
 }
 
 void metil_texture_store_add(
@@ -58,7 +58,7 @@ void metil_texture_store_add(
     metil_texture_store->length_textures +
     length_textures
   );
-  
+
   clic3_memory_reallocate_raw(
     &metil_texture_store->textures,
     (
@@ -70,14 +70,14 @@ void metil_texture_store_add(
   );
 
   va_list textures;
-  
+
   va_start(
     textures,
     length_textures
   );
-  
+
   char* texture_path;
-  
+
   for (
     unsigned int index_texture = (
       0x00
@@ -94,11 +94,11 @@ void metil_texture_store_add(
         char*
       )
     );
-    
+
     NSError* error = (
       0x00
     );
-    
+
     NSString* texture_path_string = [
       [
         NSString
@@ -108,7 +108,7 @@ void metil_texture_store_add(
         texture_path
       )
     ];
-    
+
     NSURL* url_texture = [
       NSURL
       fileURLWithPath: (
@@ -121,12 +121,12 @@ void metil_texture_store_add(
         metil_texture_store->url_directory_textures
       )
     ];
-    
+
     [
       url_texture
       retain
-    ]; 
-    
+    ];
+
     id<MTLTexture> texture = [
       metil_texture_store->loader
       newTextureWithContentsOfURL: (
@@ -139,12 +139,12 @@ void metil_texture_store_add(
         error
       )
     ];
-    
+
     [
       texture_path_string
       release
     ];
-    
+
     if (
       error !=
       0x00
@@ -155,7 +155,7 @@ void metil_texture_store_add(
       ] = (
         0x00
       );
-      
+
       NSString* string_url = (
         url_texture.path
       );
@@ -176,16 +176,16 @@ void metil_texture_store_add(
         texture
       );
     }
-    
+
     [
       url_texture
       release
     ];
   }
-  
+
   va_end(
     textures
-  );  
+  );
 }
 
 void metil_texture_store_destroy(
@@ -208,11 +208,11 @@ void metil_texture_store_destroy(
       release
     ];
   }
-  
+
   clic3_memory_free_raw(
     metil_texture_store->textures
   );
-  
+
   [
     metil_texture_store->loader
     release


### PR DESCRIPTION
- `metil_paths_foundation`:add
- - used for foundation types (`NSString` | `NSURL`)
- `metil_debug_log_level_info`:add
- `metil_debug_log`
- - add parameterized functions to allow passing parameters to logging
- `metil_texture_store`
- - use `metil_paths_foundation`