### PR TITLE
[enh] `metil_window`:add->{`prevent_recording`|`allow_recording`};

### DIFF
--- a/sources/metil_application/metil_window.m
+++ b/sources/metil_application/metil_window.m
@@ -349,7 +349,8 @@
 - (void) prevent_recording {
   self.sharingType = (
     NSWindowSharingNone
-  );}
+  );
+}
 
 @end
 

--- a/sources/metil_application/metil_window.m
+++ b/sources/metil_application/metil_window.m
@@ -340,6 +340,17 @@
   self->metil = _metil;
 }
 
+- (void) allow_recording {
+  self.sharingType = (
+    NSWindowSharingReadOnly
+  );
+}
+
+- (void) prevent_recording {
+  self.sharingType = (
+    NSWindowSharingNone
+  );}
+
 @end
 
 #endif


### PR DESCRIPTION
- `metil_window`:add->{`prevent_recording`|`allow_recording`};
- - these have to be called from within `windowDidLoad` from `NSWindowController`|`metil_window_controller`

<img width="818" height="524" alt="Screenshot 2026-06-02 at 05 04 28" src="https://github.com/user-attachments/assets/347f8345-6bda-47bd-ae4b-9b15c3f297da" />

causes errora during direct window capture and any non direct captures will have a completely transparent window (captures whats underneath the window).

may be possible to set this later on in the application lifecycle but currently it seemingly has to be set during window initialization