### PR TITLE
[enh] `metil_application_functions`:add

### DIFF
--- a/include/metil_application/metil_application_functions.h
+++ b/include/metil_application/metil_application_functions.h
@@ -1,0 +1,33 @@
+#ifndef __metil_metil_application_metil_application_functions_h
+#define __metil_metil_application_metil_application_functions_h
+
+#include <metil_application/metil_application_mapping.h>
+
+#include <QuartzCore/CAMetalLayer.h>
+
+unsigned char metil_application_function_display_sync_get(
+  struct metil_application_mapping* _Nonnull
+);
+
+unsigned char metil_application_function_display_sync_get_raw(
+  CAMetalLayer* _Nonnull
+);
+
+void metil_application_function_display_sync_lock(
+  struct metil_application_mapping* _Nonnull
+);
+
+void metil_application_function_display_sync_lock_raw(
+  CAMetalLayer* _Nonnull
+);
+
+void metil_application_function_display_sync_unlock(
+  struct metil_application_mapping* _Nonnull
+);
+
+void metil_application_function_display_sync_unlock_raw(
+  CAMetalLayer* _Nonnull
+);
+  
+#endif
+

--- a/include/metil_application/metil_application_functions.h
+++ b/include/metil_application/metil_application_functions.h
@@ -5,6 +5,7 @@
 
 #include <QuartzCore/CAMetalLayer.h>
 
+#if !target_os_ios
 unsigned char metil_application_function_display_sync_get(
   struct metil_application_mapping* _Nonnull
 );
@@ -28,6 +29,7 @@ void metil_application_function_display_sync_unlock(
 void metil_application_function_display_sync_unlock_raw(
   CAMetalLayer* _Nonnull
 );
-  
+#endif
+    
 #endif
 

--- a/sources/metil_application/metil_application_functions.m
+++ b/sources/metil_application/metil_application_functions.m
@@ -4,6 +4,7 @@
 
 #include <QuartzCore/CAMetalLayer.h>
 
+#if !target_os_ios
 unsigned char metil_application_function_display_sync_get(
   struct metil_application_mapping* metil_application_mapping
 ) {
@@ -53,3 +54,4 @@ void metil_application_function_display_sync_unlock_raw(
     0x00
   );
 }
+#endif

--- a/sources/metil_application/metil_application_functions.m
+++ b/sources/metil_application/metil_application_functions.m
@@ -1,0 +1,55 @@
+#include <metil_application/metil_application_functions.h>
+
+#include <metil_application/metil_application_mapping.h>
+
+#include <QuartzCore/CAMetalLayer.h>
+
+unsigned char metil_application_function_display_sync_get(
+  struct metil_application_mapping* metil_application_mapping
+) {
+  return (
+    metil_application_function_display_sync_get_raw(
+      metil_application_mapping->layer
+    )
+  );
+}
+
+unsigned char metil_application_function_display_sync_get_raw(
+  CAMetalLayer* metal_layer
+) {
+  return (
+    metal_layer.displaySyncEnabled
+  );
+}
+
+void metil_application_function_display_sync_lock(
+  struct metil_application_mapping* metil_application_mapping
+) {
+  metil_application_function_display_sync_lock_raw(
+    metil_application_mapping->layer
+  );
+}
+
+void metil_application_function_display_sync_lock_raw(
+  CAMetalLayer* metal_layer
+) {
+  metal_layer.displaySyncEnabled = (
+    0x01
+  );
+}
+
+void metil_application_function_display_sync_unlock(
+  struct metil_application_mapping* metil_application_mapping
+) {
+  metil_application_function_display_sync_unlock_raw(
+    metil_application_mapping->layer
+  );
+}
+
+void metil_application_function_display_sync_unlock_raw(
+  CAMetalLayer* metal_layer
+) {
+  metal_layer.displaySyncEnabled = (
+    0x00
+  );
+}


### PR DESCRIPTION
- `metil_application_functions`:add
- - `metil_application_display_sync_get`
- - - returns whether the display is sync locked or not
- - `metil_application_display_sync_lock`
- - - locks the display to sync to the refresh rate
- - `metil_application_display_sync_unlock`
- - - unlocks the display sync from the refresh rate
- - - - allows frame rates higher than display capabilities

## example:`metil_application_display_sync_unlock`

```c
metil_application_display_sync_unlock(
  metil->application_mapping
);
```

<img width="70" height="37" alt="Screenshot 2026-06-02 at 06 11 50" src="https://github.com/user-attachments/assets/501dd0c7-66b3-4953-8384-56badad53768" />
<img width="88" height="32" alt="Screenshot 2026-06-02 at 06 11 54" src="https://github.com/user-attachments/assets/455dac65-6f69-411f-86cd-56aeb7441679" />
<img width="70" height="34" alt="Screenshot 2026-06-02 at 06 12 03" src="https://github.com/user-attachments/assets/53547c70-0aae-42cc-a5e1-f75f340c1eef" />
<img width="74" height="38" alt="Screenshot 2026-06-02 at 06 12 13" src="https://github.com/user-attachments/assets/b3a02132-e64c-49fe-ae9d-9e4ca3143732" />
<img width="66" height="29" alt="Screenshot 2026-06-02 at 06 12 31" src="https://github.com/user-attachments/assets/27dd723f-5c66-4013-876d-4eba3353f25a" />

https://github.com/user-attachments/assets/9d5cd8f1-fbce-4eb2-9844-19c8b7db7cea

