### PR TITLE
[doc|enh] `metil_configuration->display_sync`

### DIFF
--- a/include/metil_configuration/metil_configuration_rendering_properties.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties.h
@@ -11,6 +11,8 @@ struct metil_configuration_rendering_properties {
 
   unsigned char fps_display;
   struct math_c_vector4_float colour_fps_display;
+  
+  unsigned char display_sync;
 
   struct metil_configuration_rendering_properties_defaults defaults;
 };

--- a/include/metil_configuration/metil_configuration_rendering_properties.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties.h
@@ -12,7 +12,9 @@ struct metil_configuration_rendering_properties {
   unsigned char fps_display;
   struct math_c_vector4_float colour_fps_display;
   
+  #if !target_os_ios
   unsigned char display_sync;
+  #endif
 
   struct metil_configuration_rendering_properties_defaults defaults;
 };

--- a/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
@@ -3,15 +3,17 @@
 
 #include <math_c_vector.h>
 
-#define metil_configuration_rendering_properties_default_brightness 1.0
-#define metil_configuration_rendering_properties_default_brightness_text 1.0
+#define metil_configuration_rendering_properties_default_brightness 0x01
+#define metil_configuration_rendering_properties_default_brightness_text 0x01
 
-#define metil_configuration_rendering_properties_default_fps_display 0
+#define metil_configuration_rendering_properties_default_fps_display 0x00
 
-#define metil_configuration_rendering_properties_default_colour_fps_display_x 1.0f
-#define metil_configuration_rendering_properties_default_colour_fps_display_y 1.0f
-#define metil_configuration_rendering_properties_default_colour_fps_display_z 1.0f
-#define metil_configuration_rendering_properties_default_colour_fps_display_w 1.0f
+#define metil_configuration_rendering_properties_default_colour_fps_display_x 0x01
+#define metil_configuration_rendering_properties_default_colour_fps_display_y 0x01
+#define metil_configuration_rendering_properties_default_colour_fps_display_z 0x01
+#define metil_configuration_rendering_properties_default_colour_fps_display_w 0x01
+
+#define metil_configuration_rendering_properties_default_display_sync 0x01
 
 struct metil_configuration_rendering_properties_defaults {
   float brightness;
@@ -19,6 +21,8 @@ struct metil_configuration_rendering_properties_defaults {
 
   unsigned char fps_display;
   struct math_c_vector4_float colour_fps_display;
+  
+  unsigned char display_sync;
 
   unsigned char initialized;
 };

--- a/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
@@ -13,7 +13,9 @@
 #define metil_configuration_rendering_properties_default_colour_fps_display_z 0x01
 #define metil_configuration_rendering_properties_default_colour_fps_display_w 0x01
 
+#if !target_os_ios
 #define metil_configuration_rendering_properties_default_display_sync 0x01
+#endif
 
 struct metil_configuration_rendering_properties_defaults {
   float brightness;
@@ -22,7 +24,9 @@ struct metil_configuration_rendering_properties_defaults {
   unsigned char fps_display;
   struct math_c_vector4_float colour_fps_display;
   
+  #if !target_os_ios
   unsigned char display_sync;
+  #endif
 
   unsigned char initialized;
 };

--- a/readme.md
+++ b/readme.md
@@ -246,6 +246,7 @@ by default these are the configuration keys and values that `metil` parses for
 - `rendering_properties:colour_fps_display_g`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
 - `rendering_properties:colour_fps_display_b`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
 - `rendering_properties:colour_fps_display_a`: floating point value greater than or equal to `0.0f` and less than or equal to `1.0f`
+- `rendering_properties:display_sync`: integer value (`0`: unlock display sync, `1`: lock display sync)::defaults_to->{`1`};
 
 #### key_value_pair_format
 
@@ -271,6 +272,7 @@ rendering_properties:colour_fps_display_r->{0.923f};
 rendering_properties:colour_fps_display_g->{0.843f};
 rendering_properties:colour_fps_display_b->{0.114f};
 rendering_properties:colour_fps_display_a->{1.0f};
+rendering_properties:display_sync->{1};
 ```
 
 ### input

--- a/sources/metil_application/metil_view_controller.m
+++ b/sources/metil_application/metil_view_controller.m
@@ -1,6 +1,7 @@
 #include <metil_application/metil_view_controller.h>
 
 #include <metil_application/metil_application.h>
+#include <metil_application/metil_application_functions.h>
 #include <metil_application/metil_application_mapping.h>
 #include <metil_application/metil_view.h>
 #include <metil_application/metil_window.h>
@@ -110,6 +111,19 @@ metil_view_controller_on_view_did_load_function metil_view_controller_on_view_di
   metil_application_mapping->layer = (
     layer
   );
+  
+  if (
+    self->metil->configuration.rendering_properties.display_sync ==
+    0x00
+  ) {
+    metil_application_function_display_sync_unlock_raw(
+      layer
+    );  
+  } else {
+    metil_application_function_display_sync_lock_raw(
+      layer
+    );
+  }
         
   [
     view

--- a/sources/metil_application/metil_view_controller.m
+++ b/sources/metil_application/metil_view_controller.m
@@ -112,6 +112,7 @@ metil_view_controller_on_view_did_load_function metil_view_controller_on_view_di
     layer
   );
   
+  #if !target_os_ios
   if (
     self->metil->configuration.rendering_properties.display_sync ==
     0x00
@@ -124,6 +125,7 @@ metil_view_controller_on_view_did_load_function metil_view_controller_on_view_di
       layer
     );
   }
+  #endif
         
   [
     view

--- a/sources/metil_configuration/metil_configuration.m
+++ b/sources/metil_configuration/metil_configuration.m
@@ -36,7 +36,9 @@ unsigned char metil_configuration_load(
     metil_configuration
   );
 
-  unsigned char status_configuration_load = 0;
+  unsigned char status_configuration_load = (
+    0x00
+  );
 
   FILE* file_configuration = fopen(
     metil_paths->file_configuration,
@@ -48,7 +50,8 @@ unsigned char metil_configuration_load(
   );
 
   if (
-    file_configuration == 0
+    file_configuration ==
+    0x00
   ) {
     metil_debug_log_error(
       metil_configuration->debug_log_level,
@@ -63,7 +66,9 @@ unsigned char metil_configuration_load(
     return status_configuration_load;
   }
 
-  unsigned int length_buffer = 0;
+  unsigned int length_buffer = (
+    0x00
+  );
 
   char* buffer = (
     clic3_memory_allocate_raw(
@@ -74,7 +79,8 @@ unsigned char metil_configuration_load(
   while (
     feof(
       file_configuration
-    ) == 0
+    ) ==
+    0x00
   ) {
     char c = (
       getc(
@@ -85,10 +91,10 @@ unsigned char metil_configuration_load(
     if (
       (
         length_buffer +
-        1
+        0x01
       ) >= (
         UINT_MAX -
-        1
+        0x01
       )
     ) {
       metil_debug_log_error(
@@ -98,45 +104,65 @@ unsigned char metil_configuration_load(
 
       status_configuration_load = (
         status_configuration_load +
-        1
+        0x01
       );
 
-      length_buffer = 0;
+      length_buffer = (
+        0x00
+      );
 
       continue;
     }
 
     if (
-      c == EOF ||
-      c == '\n'
+      (
+        c ==
+        EOF
+      ) ||
+      (
+        c ==
+        '\n'
+      )
     ) {
       if (
-        length_buffer != 0
+        length_buffer !=
+        0x00
       ) {
-        unsigned int index_pointer = 0;
+        unsigned int index_pointer = (
+          0x00
+        );
 
         for (
-          unsigned int index_buffer = 0;
-          index_buffer < length_buffer;
+          unsigned int index_buffer = (
+            0x00
+          );
+          (
+            index_buffer <
+            length_buffer
+          );
           ++index_buffer
         ) {
           if (
             buffer[
               index_buffer
-            ] == '-'
+            ] ==
+            '-'
           ) {
-            index_pointer = index_buffer;
+            index_pointer = (
+              index_buffer
+            );
+            
             break;
           }
         }
 
         if (
-          index_pointer == 0 ||
-          index_pointer + 5 >= length_buffer ||
-          buffer[index_pointer + 1] != '>' ||
-          buffer[index_pointer + 2] != '{' ||
-          buffer[length_buffer - 2] != '}' ||
-          buffer[length_buffer - 1] != ';'
+          index_pointer == 0x00 ||
+          index_pointer + 0x05 >= length_buffer ||
+          buffer[index_pointer + 0x01] != '>' ||
+          buffer[index_pointer + 0x02] != '{' ||
+          buffer[length_buffer - 0x02] != '}' ||
+          buffer[length_buffer - 0x01] != ';'
         ) {
           metil_debug_log_error(
             metil_configuration->debug_log_level,
@@ -145,7 +171,7 @@ unsigned char metil_configuration_load(
 
           status_configuration_load = (
             status_configuration_load +
-            1
+            0x01
           );
 
           break;
@@ -158,7 +184,7 @@ unsigned char metil_configuration_load(
         char* buffer_parameter = (
           clic3_memory_allocate_raw(
             length_buffer_parameter +
-            1
+            0x01
           )
         );
 
@@ -170,33 +196,47 @@ unsigned char metil_configuration_load(
 
         buffer_parameter[
           length_buffer_parameter
-        ] = '\0';
+        ] = (
+          '\0'
+        );
 
         unsigned int length_buffer_value = (
-          (length_buffer - 2) -
-          (index_pointer + 3)
+          (
+            length_buffer -
+            0x02
+          ) -
+          (
+            index_pointer +
+            0x03
+          )
         );
 
         char* buffer_value = (
           clic3_memory_allocate_raw(
             length_buffer_value +
-            1
+            0x01
           )
         );
 
         clic3_bytes_copy(
           buffer_value,
-          buffer + index_pointer + 3,
+          (
+            buffer +
+            index_pointer +
+            0x03
+          ),
           length_buffer_value
         );
 
         buffer_value[
           length_buffer_value
-        ] = '\0';
+        ] = (
+          '\0'
+        );
 
         int index_parameter = clic3_char_arrays_within(
           buffer_parameter,
-          8,
+          0x09,
           "audio:volume",
           "rendering_properties:brightness",
           "rendering_properties:brightness_text",
@@ -204,13 +244,14 @@ unsigned char metil_configuration_load(
           "rendering_properties:colour_fps_display_r",
           "rendering_properties:colour_fps_display_g",
           "rendering_properties:colour_fps_display_b",
-          "rendering_properties:colour_fps_display_a"
+          "rendering_properties:colour_fps_display_a",
+          "rendering_properties:display_sync"
         );
 
         switch (
           index_parameter
         ) {
-          case -1: {
+          case -0x01: {
             char* message_debug_log_error_prefix = (
               clic3_char_arrays_concatenate(
                 "unknown_configuration_parameter->{",
@@ -240,88 +281,112 @@ unsigned char metil_configuration_load(
 
             status_configuration_load = (
               status_configuration_load +
-              1
+              0x01
             );
 
             break;
           }
-          case 0: {
-            float audio_volume = metil_configuration_value_float_parse(
-              metil_configuration,
-              buffer_parameter,
-              buffer_value
-            );
-
-            if (
-              audio_volume >= 0.0f
-            ) {
-              metil_configuration->audio.volume = audio_volume;
-            } else {
-              status_configuration_load = (
-                status_configuration_load +
-                1
-              );
-            }
-
-            break;
-          }
-          case 1: {
-            float rendering_brightness = metil_configuration_value_float_parse(
-              metil_configuration,
-              buffer_parameter,
-              buffer_value
-            );
-
-            if (rendering_brightness >= 0.0f) {
-              metil_configuration->rendering_properties.brightness = rendering_brightness;
-            } else {
-              status_configuration_load = (
-                status_configuration_load +
-                1
-              );
-            }
-
-            break;
-          }
-          case 2: {
-            float rendering_brightness_text = metil_configuration_value_float_parse(
-              metil_configuration,
-              buffer_parameter,
-              buffer_value
-            );
-
-            if (rendering_brightness_text >= 0.0f) {
-              metil_configuration->rendering_properties.brightness_text = rendering_brightness_text;
-            } else {
-              status_configuration_load = (
-                status_configuration_load +
-                1
-              );
-            }
-
-            break;
-          }
-          case 3: {
-            int fps_display = metil_configuration_value_int_parse(
-              metil_configuration,
-              buffer_parameter,
-              buffer_value
+          case 0x00: {
+            float audio_volume = (
+              metil_configuration_value_float_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
             );
 
             if (
-              fps_display != -1
+              audio_volume >=
+              0x00
             ) {
-              metil_configuration->rendering_properties.fps_display = fps_display;
+              metil_configuration->audio.volume = (
+                audio_volume
+              );
             } else {
               status_configuration_load = (
                 status_configuration_load +
-                1
+                0x01
               );
             }
 
             break;
           }
-          case 4: {
+          case 0x01: {
+            float rendering_brightness = (
+              metil_configuration_value_float_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
+            );
+
+            if (
+              rendering_brightness >=
+              0x00
+            ) {
+              metil_configuration->rendering_properties.brightness = (
+                rendering_brightness
+              );
+            } else {
+              status_configuration_load = (
+                status_configuration_load +
+                0x01
+              );
+            }
+
+            break;
+          }
+          case 0x02: {
+            float rendering_brightness_text = (
+              metil_configuration_value_float_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
+            );
+
+            if (
+              rendering_brightness_text >=
+              0x00
+            ) {
+              metil_configuration->rendering_properties.brightness_text = (
+                rendering_brightness_text
+              );
+            } else {
+              status_configuration_load = (
+                status_configuration_load +
+                0x01
+              );
+            }
+
+            break;
+          }
+          case 0x03: {
+            int fps_display = (
+              metil_configuration_value_int_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
+            );
+
+            if (
+              fps_display !=
+              -0x01
+            ) {
+              metil_configuration->rendering_properties.fps_display = (
+                fps_display
+              );
+            } else {
+              status_configuration_load = (
+                status_configuration_load +
+                0x01
+              );
+            }
+
+            break;
+          }
+          case 0x04: {
             float colour_fps_display_r = metil_configuration_value_float_parse(
               metil_configuration,
               buffer_parameter,
@@ -329,8 +394,14 @@ unsigned char metil_configuration_load(
             );
 
             if (
-              colour_fps_display_r >= 0.0f &&
-              colour_fps_display_r <= 1.0f
+              (
+                colour_fps_display_r >=
+                0x00
+              ) &&
+              (
+                colour_fps_display_r <=
+                0x01
+              )
             ) {
               metil_configuration->rendering_properties.colour_fps_display.x = (
                 colour_fps_display_r
@@ -338,13 +409,13 @@ unsigned char metil_configuration_load(
             } else {
               status_configuration_load = (
                 status_configuration_load +
-                1
+                0x01
               );
             }
 
             break;
           }
-          case 5: {
+          case 0x05: {
             float colour_fps_display_g = metil_configuration_value_float_parse(
               metil_configuration,
               buffer_parameter,
@@ -352,8 +423,14 @@ unsigned char metil_configuration_load(
             );
 
             if (
-              colour_fps_display_g >= 0.0f &&
-              colour_fps_display_g <= 1.0f
+              (
+                colour_fps_display_g >=
+                0x00
+              ) &&
+              (
+                colour_fps_display_g <=
+                0x01
+              )
             ) {
               metil_configuration->rendering_properties.colour_fps_display.y = (
                 colour_fps_display_g
@@ -361,22 +438,30 @@ unsigned char metil_configuration_load(
             } else {
               status_configuration_load = (
                 status_configuration_load +
-                1
+                0x01
               );
             }
 
             break;
           }
-          case 6: {
-            float colour_fps_display_b = metil_configuration_value_float_parse(
-              metil_configuration,
-              buffer_parameter,
-              buffer_value
+          case 0x06: {
+            float colour_fps_display_b = (
+              metil_configuration_value_float_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
             );
 
             if (
-              colour_fps_display_b >= 0.0f &&
-              colour_fps_display_b <= 1.0f
+              (
+                colour_fps_display_b >=
+                0x00
+              ) &&
+              (
+                colour_fps_display_b <=
+                0x01
+              )
             ) {
               metil_configuration->rendering_properties.colour_fps_display.z = (
                 colour_fps_display_b
@@ -384,22 +469,30 @@ unsigned char metil_configuration_load(
             } else {
               status_configuration_load = (
                 status_configuration_load +
-                1
+                0x01
               );
             }
 
             break;
           }
-          case 7: {
-            float colour_fps_display_a = metil_configuration_value_float_parse(
-              metil_configuration,
-              buffer_parameter,
-              buffer_value
+          case 0x07: {
+            float colour_fps_display_a = (
+              metil_configuration_value_float_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
             );
 
             if (
-              colour_fps_display_a >= 0.0f &&
-              colour_fps_display_a <= 1.0f
+              (
+                colour_fps_display_a >=
+                0x00
+              ) &&
+              (
+                colour_fps_display_a <=
+                0x01
+              )
             ) {
               metil_configuration->rendering_properties.colour_fps_display.w = (
                 colour_fps_display_a
@@ -407,7 +500,38 @@ unsigned char metil_configuration_load(
             } else {
               status_configuration_load = (
                 status_configuration_load +
-                1
+                0x01
+              );
+            }
+
+            break;
+          }
+          case 0x08: {
+            int display_sync = (
+              metil_configuration_value_int_parse(
+                metil_configuration,
+                buffer_parameter,
+                buffer_value
+              )
+            );
+
+            if (
+              (
+                display_sync ==
+                0x00
+              ) ||
+              (
+                display_sync ==
+                0x01
+              )
+            ) {
+              metil_configuration->rendering_properties.display_sync = (
+                display_sync
+              );
+            } else {
+              status_configuration_load = (
+                status_configuration_load +
+                0x01
               );
             }
 
@@ -423,12 +547,14 @@ unsigned char metil_configuration_load(
           buffer_value
         );
 
-        length_buffer = 0;
+        length_buffer = (
+          0x00
+        );
       }
     } else {
       length_buffer = (
         length_buffer +
-        1
+        0x01
       );
 
       clic3_memory_reallocate_raw(
@@ -438,7 +564,7 @@ unsigned char metil_configuration_load(
 
       buffer[
         length_buffer -
-        1
+        0x01
       ] = (
         c
       );
@@ -471,9 +597,9 @@ int metil_configuration_value_int_parse(
   );
 
   if (
-    valid_parameter != 0 ||
-    value_int != 0 &&
-    value_int != 1
+    valid_parameter != 0x00 ||
+    value_int != 0x00 &&
+    value_int != 0x01
   ) {
     metil_configuration_debug_log_parameter_invalid(
       metil_configuration,
@@ -481,10 +607,14 @@ int metil_configuration_value_int_parse(
       value
     );
 
-    return -1;
+    return -(
+      0x01
+    );
   }
 
-  return value_int;
+  return (
+    value_int
+  );
 }
 
 float metil_configuration_value_float_parse(
@@ -494,14 +624,16 @@ float metil_configuration_value_float_parse(
 ) {
   float value_float;
 
-  unsigned char valid_parameter = clic3_char_array_to_float(
-    value,
-    &value_float
+  unsigned char valid_parameter = (
+    clic3_char_array_to_float(
+      value,
+      &value_float
+    )
   );
 
   if (
-    valid_parameter != 0 ||
-    value_float < 0.0f
+    valid_parameter != 0x00 ||
+    value_float < 0x00
   ) {
     metil_configuration_debug_log_parameter_invalid(
       metil_configuration,
@@ -509,10 +641,14 @@ float metil_configuration_value_float_parse(
       value
     );
 
-    return -1.0f;
+    return -(
+      0x01
+    );
   }
 
-  return value_float;
+  return (
+    value_float
+  );
 }
 
 void metil_configuration_debug_log_parameter_invalid(

--- a/sources/metil_configuration/metil_configuration.m
+++ b/sources/metil_configuration/metil_configuration.m
@@ -236,7 +236,11 @@ unsigned char metil_configuration_load(
 
         int index_parameter = clic3_char_arrays_within(
           buffer_parameter,
+          #if !target_os_ios
           0x09,
+          #else
+          0x08,
+          #endif
           "audio:volume",
           "rendering_properties:brightness",
           "rendering_properties:brightness_text",
@@ -244,8 +248,11 @@ unsigned char metil_configuration_load(
           "rendering_properties:colour_fps_display_r",
           "rendering_properties:colour_fps_display_g",
           "rendering_properties:colour_fps_display_b",
-          "rendering_properties:colour_fps_display_a",
+          "rendering_properties:colour_fps_display_a"
+          #if !target_os_ios
+          ,
           "rendering_properties:display_sync"
+          #endif
         );
 
         switch (
@@ -506,6 +513,7 @@ unsigned char metil_configuration_load(
 
             break;
           }
+          #if !target_os_ios
           case 0x08: {
             int display_sync = (
               metil_configuration_value_int_parse(
@@ -537,6 +545,7 @@ unsigned char metil_configuration_load(
 
             break;
           }
+          #endif
         }
 
         clic3_memory_free_raw(

--- a/sources/metil_configuration/metil_configuration_rendering_properties.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties.c
@@ -40,7 +40,9 @@ void metil_configuration_rendering_properties_initialize(
     metil_configuration_rendering_properties->defaults.colour_fps_display.w
   );
   
+  #if !target_os_ios
   metil_configuration_rendering_properties->display_sync = (
     metil_configuration_rendering_properties->defaults.display_sync
   );
+  #endif
 }

--- a/sources/metil_configuration/metil_configuration_rendering_properties.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties.c
@@ -4,7 +4,8 @@ void metil_configuration_rendering_properties_initialize(
   struct metil_configuration_rendering_properties* metil_configuration_rendering_properties
 ) {
   if (
-    metil_configuration_rendering_properties->defaults.initialized != 1
+    metil_configuration_rendering_properties->defaults.initialized !=
+    0x01
   ) {
     metil_configuration_rendering_properties_defaults_initialize(
       &metil_configuration_rendering_properties->defaults
@@ -37,5 +38,9 @@ void metil_configuration_rendering_properties_initialize(
 
   metil_configuration_rendering_properties->colour_fps_display.w = (
     metil_configuration_rendering_properties->defaults.colour_fps_display.w
+  );
+  
+  metil_configuration_rendering_properties->display_sync = (
+    metil_configuration_rendering_properties->defaults.display_sync
   );
 }

--- a/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
@@ -31,9 +31,11 @@ void metil_configuration_rendering_properties_defaults_initialize(
     metil_configuration_rendering_properties_default_colour_fps_display_w
   );
   
+  #if !target_os_ios
   metil_configuration_rendering_properties_defaults->display_sync = (
     metil_configuration_rendering_properties_default_display_sync
   );
+  #endif
 
   metil_configuration_rendering_properties_defaults->initialized = (
     0x01

--- a/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
+++ b/sources/metil_configuration/metil_configuration_rendering_properties_defaults.c
@@ -30,8 +30,12 @@ void metil_configuration_rendering_properties_defaults_initialize(
   metil_configuration_rendering_properties_defaults->colour_fps_display.w = (
     metil_configuration_rendering_properties_default_colour_fps_display_w
   );
+  
+  metil_configuration_rendering_properties_defaults->display_sync = (
+    metil_configuration_rendering_properties_default_display_sync
+  );
 
   metil_configuration_rendering_properties_defaults->initialized = (
-    1
+    0x01
   );
 }

--- a/sources/metil_configuration/metil_configuration_values_set.m
+++ b/sources/metil_configuration/metil_configuration_values_set.m
@@ -4,5 +4,7 @@ void metil_configuration_values_set(
   struct metil* metil,
   struct metil_configuration* metil_configuration
 ) {
-  metil->audio.volume = metil_configuration->audio.volume;
+  metil->audio.volume = (
+    metil_configuration->audio.volume
+  );
 }


### PR DESCRIPTION
- `metil_configuration`:add->{`display_sync`};
- - configuration value parsed from `rendering_properties:display_sync` with a type of `int` either `0` or `1`
- - - if `0`:display_sync_unlocked
- - - if `1`:display_sync_locked
- `metil_view_controller`:set_display_sync_locking::based_on->{`metil_configration->display_sync`};
- `readme.md`:add->{configuration::`rendering_properties-::display_sync`};