### PR TITLE
[enh] `metil_scene`:initializers_with_texture_lengths

### DIFF
--- a/include/metil_scenes/metil_scene.h
+++ b/include/metil_scenes/metil_scene.h
@@ -68,6 +68,19 @@ void metil_scene_initialize_with_renderables(
   unsigned int
 );
 
+void metil_scene_initialize_with_textures(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned int
+);
+
+void metil_scene_initialize_with_renderables_textures(
+  struct metil* _Nonnull,
+  struct metil_scene* _Nonnull,
+  unsigned int,
+  unsigned int
+);
+
 void metil_scene_renderables_set_length(
   struct metil_scene* _Nonnull,
   unsigned int

--- a/sources/metil_scenes/metil_scene.m
+++ b/sources/metil_scenes/metil_scene.m
@@ -16,9 +16,10 @@ void metil_scene_initialize(
   struct metil* metil,
   struct metil_scene* scene
 ) {
-  metil_scene_initialize_with_renderables(
+  metil_scene_initialize_with_renderables_textures(
     metil,
     scene,
+    0x00,
     0x00
   );
 }
@@ -27,6 +28,33 @@ void metil_scene_initialize_with_renderables(
   struct metil* metil,
   struct metil_scene* scene,
   unsigned int length_renderables
+) {
+  metil_scene_initialize_with_renderables_textures(
+    metil,
+    scene,
+    length_renderables,
+    0x00
+  );
+}
+
+void metil_scene_initialize_with_textures(
+  struct metil* metil,
+  struct metil_scene* scene,
+  unsigned int length_textures
+) {
+  metil_scene_initialize_with_renderables_textures(
+    metil,
+    scene,
+    0x00,
+    length_textures
+  );
+}
+
+void metil_scene_initialize_with_renderables_textures(
+  struct metil* metil,
+  struct metil_scene* scene,
+  unsigned int length_renderables,
+  unsigned int length_textures
 ) {
   metil_player_initialize(
     &scene->player,
@@ -47,7 +75,7 @@ void metil_scene_initialize_with_renderables(
   );
 
   scene->length_textures = (
-    0x00
+    length_textures
   );
 
   scene->textures = (

--- a/sources/metil_scenes/metil_scene.m
+++ b/sources/metil_scenes/metil_scene.m
@@ -10,6 +10,8 @@
 
 #include <clic3_memory.h>
 
+#include <Metal/MTLTexture.h>
+
 void metil_scene_initialize(
   struct metil* metil,
   struct metil_scene* scene
@@ -17,7 +19,7 @@ void metil_scene_initialize(
   metil_scene_initialize_with_renderables(
     metil,
     scene,
-    0
+    0x00
   );
 }
 
@@ -44,45 +46,102 @@ void metil_scene_initialize_with_renderables(
     )
   );
 
-  scene->length_textures = 0;
+  scene->length_textures = (
+    0x00
+  );
 
   scene->textures = (
     clic3_memory_allocate_raw(
-      0
+      scene->length_textures *
+      sizeof(
+        id<MTLTexture>
+      )
     )
   );
 
-  scene->player.position.x = 0.0f;
-  scene->player.position.y = 0.0f;
-  scene->player.position.z = 0.0f;
+  scene->player.position.x = (
+    0x00
+  );
 
-  scene->player.rotation.x = 0.0f;
-  scene->player.rotation.y = 0.0f;
-  scene->player.rotation.z = 0.0f;
+  scene->player.position.y = (
+    0x00
+  );
 
-  metil->input.cursor.delta.x = 0.0f;
-  metil->input.cursor.delta.y = 0.0f;
+  scene->player.position.z = (
+    0x00
+  );
 
-  scene->poll = metil_scene_poll_default;
-  scene->poll_input = metil_scene_poll_input_default;
-  scene->destroy = metil_scene_destroy_default;
+  scene->player.rotation.x = (
+    0x00
+  );
+
+  scene->player.rotation.y = (
+    0x00
+  );
+
+  scene->player.rotation.z = (
+    0x00
+  );
+
+  metil->input.cursor.delta.x = (
+    0x00
+  );
+
+  metil->input.cursor.delta.y = (
+    0x00
+  );
+
+  scene->poll = (
+    metil_scene_poll_default
+  );
+
+  scene->poll_input = (
+    metil_scene_poll_input_default
+  );
+
+  scene->destroy = (
+    metil_scene_destroy_default
+  );
 
   scene->time_initial = (
     metil_time_milliseconds_get()
   );
 
-  scene->time = 0;
-  scene->time_previous = 0;
-  scene->time_delta = 0;
-  scene->time_elapsed = 0;
+  scene->time = (
+    0x00
+  );
 
-  scene->time_input = 0;
-  scene->time_input_delta = 0;
-  scene->time_input_previous = 0;
+  scene->time_previous = (
+    0x00
+  );
 
-  scene->loading = 0;
+  scene->time_delta = (
+    0x00
+  );
 
-  scene->data = 0;
+  scene->time_elapsed = (
+    0x00
+  );
+
+  scene->time_input = (
+    0x00
+  );
+
+  scene->time_input_delta = (
+    0x00
+  );
+
+  scene->time_input_previous = (
+    0x00
+  );
+
+  scene->loading = (
+    0x00
+  );
+
+  scene->data = (
+    0x00
+  );
 }
 
 void metil_scene_renderables_set_length(
@@ -124,8 +183,11 @@ void metil_scene_poll_input(
   metil_scene->time_input = time;
 
   metil_scene->time_input_delta = (
-    metil_scene->time_input_previous == 0
-    ? 0
+    (
+      metil_scene->time_input_previous ==
+      0x00
+    )
+    ? 0x00
     : (
       metil_scene->time_input -
       metil_scene->time_input_previous
@@ -164,11 +226,16 @@ void metil_scene_poll(
     metil_scene->time
   );
 
-  metil_scene->time = time;
+  metil_scene->time = (
+    time
+  );
 
   metil_scene->time_delta = (
-    metil_scene->time_previous == 0
-    ? 0
+    (
+      metil_scene->time_previous ==
+      0x00
+    )
+    ? 0x00
     : (
       metil_scene->time -
       metil_scene->time_previous
@@ -218,8 +285,13 @@ void metil_scene_destroy_default(
   struct metil_scene* scene
 ) {
   for (
-    unsigned int index_renderable = 0;
-    index_renderable < scene->length_renderables;
+    unsigned int index_renderable = (
+      0x00
+    );
+    (
+      index_renderable <
+      scene->length_renderables
+    );
     ++index_renderable
   ) {
     metil_renderable_destroy(
@@ -237,8 +309,13 @@ void metil_scene_destroy_default(
   );
 
   for (
-    unsigned int index_texture = 0;
-    index_texture < scene->length_textures;
+    unsigned int index_texture = (
+      0x00
+    );
+    (
+      index_texture <
+      scene->length_textures
+    );
     ++index_texture
   ) {
     [


### PR DESCRIPTION
- `metil_scene`
- - `metil_scene_initialize_with_textures`
- - - initializes `metil_scene` with textures length
- - `metil_scene_initialize_with_renderables_textures`
- - - initializes `metil_scene` with renderables length and textures length