### PR TITLE
[dev] `sources/metil_text/metil_text_render_parameters.m`:type_cast_to_silence_false_warning

### DIFF
--- a/sources/metil_text/metil_text_render_parameters.m
+++ b/sources/metil_text/metil_text_render_parameters.m
@@ -18,10 +18,13 @@ void metil_text_render_parameters_initialize(
       name_family_font
     )
   ];
-
+ 
   metil_text_render_parameters->font = (
     CTFontCreateWithName(
-      string_name_family_font,
+      (
+        (CFStringRef)
+        string_name_family_font
+      ),
       size,
       0x00
     )


### PR DESCRIPTION
`NSString`s can be used in place of `CFStringRef`s, from the header files



> "Please note: CFStrings are conceptually an array of Unicode characters.
However, in general, how a CFString stores this array is an implementation
detail. For instance, CFString might choose to use an array of 8-bit characters
to store its contents, or it might use multiple blocks of memory, or whatever.
This is especially true since CFString is toll-free bridged with NSString, enabling
any NSString instance to be used as a CFString. Furthermore, the implementation
may change depending on the default system encoding, the user's language, 
or even a release or update of the OS."

specifically this part

> "This is especially true since CFString is toll-free bridged with NSString, enabling
any NSString instance to be used as a CFString."

:)

copyright notice requirement

> /*	CFString.h
>	Copyright (c) 1998-2019, Apple Inc. and the Swift project authors
> 
>	Portions Copyright (c) 2014-2019, Apple Inc. and the Swift project authors
>	Licensed under Apache License v2.0 with Runtime Library Exception
>	See http://swift.org/LICENSE.txt for license information
>	See http://swift.org/CONTRIBUTORS.txt for the list of Swift project authors
> */


so the 

```
sources/metil_text/metil_text_render_parameters.m:24:7: warning: incompatible pointer types passing 'NSString *' to parameter of type 'CFStringRef _Nonnull' (aka 'const struct __CFString *') [-Wincompatible-pointer-types]
   24 |       string_name_family_font,
      |       ^~~~~~~~~~~~~~~~~~~~~~~
/Applications/Xcode_16.4.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX15.5.sdk/System/Library/Frameworks/CoreText.framework/Headers/CTFont.h:170:33: note: passing argument to parameter 'name' here
  170 |     CFStringRef                 name,
```
warning is incorrect

thanks, have a good day.