### PR TITLE
`metil_renderer`:add_descriptor_render_pass_initializer

### DIFF
--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -394,6 +394,9 @@
   }
 }
 
+- (void) descriptor_render_pass_initialize {
+}
+
 - (void) destroy {
   self->destroying = (
     0x01


### PR DESCRIPTION
- `metil_renderer`:add_descriptor_render_pass_initializer