### PR TITLE
[dev|enh] Ios background application changes

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -68,6 +68,11 @@
 
   @public metil_renderer_data_frame_poll_function poll_data_frame;
 
+  #if target_os_ios
+  unsigned char state_application_previous;
+  unsigned long int time_state_application_inactive;
+  #endif
+
   unsigned char destroying;
   pthread_mutex_t mutex_destroying;
 }

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -739,13 +739,14 @@
     descriptor_command_buffer
     release
   ];
-  
+
   self->descriptor_render_pass.colorAttachments[
     0x00
   ].texture = (
     metal_kit_view.currentDrawable.texture
   );
-   #if target_os_ios
+
+  #if target_os_ios
   metil_application* metil_ui_application = (
     (metil_application*)
     [
@@ -758,12 +759,51 @@
     metil_ui_application
     applicationState
   ];
-  
+
   if (
-    state_application ==
-    0x00
+    self->state_application_previous !=
+    state_application
   ) {
+    self->state_application_previous = (
+      state_application
+    );
+
+    if (
+      state_application !=
+      0x00
+    ) {
+      self->time_state_application_inactive = (
+        self->metil->rendering_properties.time_frames[
+          metil_count_time_frames -
+          0x01
+        ]
+      );
+    }
+  }
+
+  unsigned char ios_render = (
+    (
+      state_application ==
+      0x00
+    )
+    ? 0x01
+    : (
+      (
+        (
+          self->metil->rendering_properties.time_frames[
+            metil_count_time_frames -
+            0x01
+          ] -
+          self->time_state_application_inactive
+        ) <
+        0x2710
+      )
+      ? 0x01
+      : 0x00
+    )
+  );
   #endif
+
   if (
     (
       self->metil->rendering_properties.disables &
@@ -771,26 +811,6 @@
     ) ==
     0x00
   ) {
-    self->descriptor_render_pass.colorAttachments[
-      0x00
-    ].clearColor = (
-      MTLClearColorMake(
-        (
-          self->metil->rendering_properties.colour_clear.x *
-          self->metil->rendering_properties.brightness
-        ),
-        (
-          self->metil->rendering_properties.colour_clear.y *
-          self->metil->rendering_properties.brightness
-        ),
-        (
-          self->metil->rendering_properties.colour_clear.z *
-          self->metil->rendering_properties.brightness
-        ),
-        self->metil->rendering_properties.colour_clear.w
-      )
-    );
-
     self->descriptor_render_pass.colorAttachments[
       0x00
     ].clearColor = (
@@ -813,7 +833,7 @@
         )
       }
     );
-  
+
     descriptor_render_pass.colorAttachments[
       0x00
     ].loadAction = (
@@ -826,15 +846,6 @@
       MTLLoadActionLoad
     );
   }
-  #if target_os_ios
-  } else {
-    descriptor_render_pass.colorAttachments[
-      0x00
-    ].loadAction = (
-      MTLLoadActionLoad
-    );
-  }
-  #endif
 
   self->descriptor_render_pass.colorAttachments[
     0x00
@@ -921,20 +932,19 @@
       )
     ];
   }
-  
-  #if target_os_ios
-  if (
-    state_application ==
-    0x00
-  ) {  
-  #endif
 
-  if (
-    (
+  if (    (
       self->metil->rendering_properties.disables &
       metil_rendering_properties_disables_rendering
     ) ==
     0x00
+    #if target_os_ios
+    &&
+    (
+      ios_render ==
+      0x01
+    )
+    #endif
   ) {
     [
       self
@@ -957,16 +967,19 @@
       self->metil->rendering_properties.frame >
       0x0a
     )
+    #if target_os_ios
+    &&
+    (
+      ios_render ==
+      0x01
+    )
+    #endif
   ) {
     [
       self
       render_fps_display
     ];
   }
-  
-  #if target_os_ios
-  }
-  #endif
 
   [
     encoder_render

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -565,68 +565,6 @@
     )
   ];
 
-  #if target_os_ios
-  metil_application* metil_ui_application = (
-    (metil_application*)
-    [
-      UIApplication
-      sharedApplication
-    ]
-  );
-
-  unsigned char state_application = [
-    metil_ui_application
-    applicationState
-  ];
-
-  if (
-    state_application >
-    0x01
-  ) {
-    if (      self->destroying ==
-      0x00
-    ) {
-      struct timespec time_sleep = {
-        .tv_sec = (
-          0x00
-        ),
-        .tv_nsec = (
-          0x05f5e100
-        )
-      };
-
-      struct timespec time_remaining = {
-        .tv_sec = (
-          0x00
-        ),
-        .tv_nsec = (
-          0x00
-        )
-      };
-
-      nanosleep(
-        &time_sleep,
-        &time_remaining
-      );
-
-      pthread_t thread_draw;
-
-      pthread_create(
-        &thread_draw,
-        0x00,
-        metil_renderer_thread_draw,
-        metal_kit_view
-      );
-    } else {
-      pthread_mutex_unlock(
-        &self->mutex_destroying
-      );
-    }
-
-    return;
-  }
-  #endif
-
   [
     self
     render_view: (
@@ -763,30 +701,30 @@
     release
   ];
 
-  MTLRenderPassDescriptor* descriptor_render_pass = (
+  self->descriptor_render_pass = (
     metal_kit_view.currentRenderPassDescriptor
   );
-
-  descriptor_render_pass.colorAttachments[
-    0x00
-  ].clearColor = (
-    MTLClearColorMake(
-      (
-        self->metil->rendering_properties.colour_clear.x *
-        self->metil->rendering_properties.brightness
-      ),
-      (
-        self->metil->rendering_properties.colour_clear.y *
-        self->metil->rendering_properties.brightness
-      ),
-      (
-        self->metil->rendering_properties.colour_clear.z *
-        self->metil->rendering_properties.brightness
-      ),
-      self->metil->rendering_properties.colour_clear.w
-    )
+      
+  
+  #if target_os_ios
+  metil_application* metil_ui_application = (
+    (metil_application*)
+    [
+      UIApplication
+      sharedApplication
+    ]
   );
 
+  unsigned char state_application = [
+    metil_ui_application
+    applicationState
+  ];
+  
+  if (
+    state_application ==
+    0x00
+  ) {
+  #endif
   if (
     (
       self->metil->rendering_properties.disables &
@@ -794,6 +732,29 @@
     ) ==
     0x00
   ) {
+    descriptor_render_pass.colorAttachments[
+      0x00
+    ].clearColor = (
+      (MTLClearColor)
+      {
+        .red = (
+          self->metil->rendering_properties.colour_clear.x *
+          self->metil->rendering_properties.brightness
+        ),
+        .green = (
+          self->metil->rendering_properties.colour_clear.y *
+          self->metil->rendering_properties.brightness
+        ),
+        .blue = (
+          self->metil->rendering_properties.colour_clear.z *
+          self->metil->rendering_properties.brightness
+        ),
+        .alpha = (
+          self->metil->rendering_properties.colour_clear.w
+        )
+      }
+    );
+  
     descriptor_render_pass.colorAttachments[
       0x00
     ].loadAction = (
@@ -806,6 +767,15 @@
       MTLLoadActionLoad
     );
   }
+  #if target_os_ios
+  } else {
+    descriptor_render_pass.colorAttachments[
+      0x00
+    ].loadAction = (
+      MTLLoadActionLoad
+    );
+  }
+  #endif
 
   descriptor_render_pass.colorAttachments[
     0x00
@@ -892,6 +862,13 @@
       )
     ];
   }
+  
+  #if target_os_ios
+  if (
+    state_application ==
+    0x00
+  ) {  
+  #endif
 
   if (
     (
@@ -927,6 +904,10 @@
       render_fps_display
     ];
   }
+  
+  #if target_os_ios
+  }
+  #endif
 
   [
     encoder_render

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1198,6 +1198,16 @@
     0x00
   );
 
+  #if target_os_ios
+  self->state_application_previous = (
+    0xff
+  );
+
+  self->time_state_application_inactive = (
+    0x00
+  );
+  #endif
+
   self->poll_data_frame = (
     metil_renderer_data_frame_poll
   );


### PR DESCRIPTION
- remove threaded draw loop during background process
- use `MTLStoreActionLoad` during background process
- disable rendering of fps display and renderables during background process

this keeps the app running without closing after like 20 minutes

battery/performance cost should be fairly low since its just loading and displaying the previously rendered texture (though is still doing scene polls, something that should be handled within a specific implementation rather than through metil)

this is a draft until render descriptor stuff is settled that way it doesnt pull from three different textures during `MTLStoreActionLoad`