### PR TITLE
[dev|enh] Clear input on did resign active

### DIFF
--- a/include/metil_application/metil_application_delegate.h
+++ b/include/metil_application/metil_application_delegate.h
@@ -22,6 +22,7 @@
 #endif
 
 - (void) applicationWillTerminate: (NSNotification*) notification;
+- (void) applicationDidResignActive: (NSNotification*) notification;
 
 @end
 

--- a/include/metil_configuration/metil_configuration.h
+++ b/include/metil_configuration/metil_configuration.h
@@ -1,12 +1,14 @@
 #ifndef __metil_configuration_metil_configuration_h
 #define __metil_configuration_metil_configuration_h
 
+#include <metil_configuration/metil_configuration_application.h>
 #include <metil_configuration/metil_configuration_audio.h>
 #include <metil_configuration/metil_configuration_rendering_properties.h>
 #include <metil_debug/metil_debug_log_level.h>
 #include <metil_paths/metil_paths.h>
 
 struct metil_configuration {
+  struct metil_configuration_application application;
   struct metil_configuration_audio audio;
   struct metil_configuration_rendering_properties rendering_properties;
   enum metil_debug_log_level debug_log_level;

--- a/include/metil_configuration/metil_configuration_application.h
+++ b/include/metil_configuration/metil_configuration_application.h
@@ -1,0 +1,12 @@
+#ifndef __metil_metil_configuration_metil_configuration_application_h
+#define __metil_metil_configuration_metil_configuration_application_h
+
+struct metil_configuration_application {
+  unsigned char clear_input_on_deactivation;
+};
+
+void metil_configuration_application_initialize(
+  struct metil_configuration_application*
+);
+
+#endif

--- a/include/metil_configuration/metil_configuration_audio.h
+++ b/include/metil_configuration/metil_configuration_audio.h
@@ -1,10 +1,14 @@
 #ifndef __metil_configuration_metil_configuration_audio_h
 #define __metil_configuration_metil_configuration_audio_h
 
-#define metil_configuration_default_audio_volume 1.0f
+#define metil_configuration_default_audio_volume 0x01
 
 struct metil_configuration_audio {
   float volume;
 };
+
+void metil_configuration_audio_initialize(
+  struct metil_configuration_audio*
+);
 
 #endif

--- a/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
+++ b/include/metil_configuration/metil_configuration_rendering_properties_defaults.h
@@ -1,5 +1,5 @@
-#ifndef __metil_configuration_metil_configuration_defaults_h
-#define __metil_configuration_metil_configuration_defaults_h
+#ifndef __metil_configuration_metil_configuration_rendering_properties_defaults_h
+#define __metil_configuration_metil_configuration_rendering_properties_defaults_h
 
 #include <math_c_vector.h>
 

--- a/sources/metil_application/metil_application_delegate.m
+++ b/sources/metil_application/metil_application_delegate.m
@@ -10,4 +10,15 @@
   );
 }
 
+- (void) applicationDidResignActive: (NSNotification*) notification {
+  if (
+    self->metil->configuration.application.clear_input_on_deactivation !=
+    0x00
+  ) {
+    metil_input_keydown_map_initialize(
+      self->metil->input.keydown_map
+    );
+  }
+}
+
 @end

--- a/sources/metil_configuration/metil_configuration.m
+++ b/sources/metil_configuration/metil_configuration.m
@@ -2,6 +2,9 @@
 
 #include <metil.h>
 #include <metil_audio/metil_audio_data.h>
+#include <metil_configuration/metil_configuration_application.h>
+#include <metil_configuration/metil_configuration_audio.h>
+#include <metil_configuration/metil_configuration_rendering_properties.h>
 #include <metil_debug/metil_debug_log.h>
 #include <metil_paths/metil_paths.h>
 
@@ -15,12 +18,16 @@
 void metil_configuration_initialize(
   struct metil_configuration* metil_configuration
 ) {
-  metil_configuration->audio.volume = (
-    metil_configuration_default_audio_volume
-  );
-
   metil_configuration->debug_log_level = (
     metil_debug_log_level_error
+  );
+
+  metil_configuration_application_initialize(
+    &metil_configuration->application
+  );
+
+  metil_configuration_audio_initialize(
+    &metil_configuration->audio
   );
 
   metil_configuration_rendering_properties_initialize(

--- a/sources/metil_configuration/metil_configuration_application.c
+++ b/sources/metil_configuration/metil_configuration_application.c
@@ -1,0 +1,9 @@
+#include <metil_configuration/metil_configuration_application.h>
+
+void metil_configuration_application_initialize(
+  struct metil_configuration_application* metil_configuration_application
+) {
+  metil_configuration_application->clear_input_on_deactivation = (
+    0x01
+  );
+}

--- a/sources/metil_configuration/metil_configuration_audio.c
+++ b/sources/metil_configuration/metil_configuration_audio.c
@@ -1,0 +1,9 @@
+#include <metil_configuration/metil_configuration_audio.h>
+
+void metil_configuration_audio_initialize(
+  struct metil_configuration_audio* metil_configuration_audio
+) {
+  metil_configuration_audio->volume = (
+    metil_configuration_default_audio_volume
+  );
+}


### PR DESCRIPTION
- `metil_configuration_application`:add
- - `clear_input_on_deactivation`:
- - - when application is no longer active clear input keydown mapping
- - - fixes application getting "sticky" keys when switching between applications
- `metil_configuration_audio`:add_initializer
- `metil_application_delegate`:add->{`applicationDidResignActive`};
- - used to clear input keydown mapping
- `metil_configuration_rendering_properties_defaults`:full_header_guard_pathing
- `metil_configuration`:
- - use->{`metil_configuration_audio_initialize`};
- - use->{`metil_configuration_application_initialize`);