### PR TITLE
[dev] `metil_renderer`:use->{`self`};

### DIFF
--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -763,7 +763,7 @@
     release
   ];
 
-  MTLRenderPassDescriptor* descriptor_render_pass = (
+  self->descriptor_render_pass = (
     metal_kit_view.currentRenderPassDescriptor
   );
 


### PR DESCRIPTION
- `metil_renderer`:use->{`self`};
- - removes the warning about local variable versus instance