### PR TITLE
[dev] `examples/3d_rendering/metal/3d_rendering_sky`:remove_unused_sampler

### DIFF
--- a/examples/3d_rendering/metal/3d_rendering_sky.metal
+++ b/examples/3d_rendering/metal/3d_rendering_sky.metal
@@ -142,10 +142,6 @@
     data_vertex_basic_textured_coloured.colour
   );
 
-  constexpr metal::sampler sampler_texture_sky(
-    metal::mag_filter::linear
-  );
-
   return (
     colour_output
   );


### PR DESCRIPTION
- `examples/3d_rendering/metal/3d_rendering_sky`:remove_unused_sampler
- - just clearing a warning about an unused variable