### PR TITLE
[dev] `metil_descriptor_render_pass`:implement_use

### DIFF
--- a/include/metil_rendering/metil_descriptors/metil_render_pass.h
+++ b/include/metil_rendering/metil_descriptors/metil_render_pass.h
@@ -1,0 +1,12 @@
+#ifndef __metil_metil_rendering_metil_descriptors_metil_render_pass_h
+#define __metil_metil_rendering_metil_descriptors_metil_render_pass_h
+
+#include <Metal/MTLDevice.h>
+#include <Metal/MTLRenderPass.h>
+
+void metil_descriptor_render_pass_initialize(
+  MTLRenderPassDescriptor* _Nonnull,
+  id<MTLDevice> _Nonnull
+);
+
+#endif

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -16,6 +16,7 @@
 #include <Metal/MTLDevice.h>
 #include <Metal/MTLLibrary.h>
 #include <Metal/MTLRenderCommandEncoder.h>
+#include <Metal/MTLRenderPass.h>
 #include <Metal/MTLRenderPipeline.h>
 #include <MetalKit/MTKView.h>
 

--- a/sources/metil_rendering/metil_descriptors/metil_render_pass.m
+++ b/sources/metil_rendering/metil_descriptors/metil_render_pass.m
@@ -1,0 +1,11 @@
+#include <metil_rendering/metil_descriptors/metil_render_pass.h>
+
+#include <Metal/MTLDevice.h>
+#include <Metal/MTLRenderPass.h>
+#include <Metal/MTLTexture.h>
+
+void metil_descriptor_render_pass_initialize(
+  MTLRenderPassDescriptor* descriptor_render_pass,
+  id<MTLDevice> metal_device
+) {
+}

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -11,6 +11,7 @@
 #include <metil_object.h>
 #include <metil_positioning.h>
 #include <metil_rendering/metil_camera/metil_camera.h>
+#include <metil_rendering/metil_descriptors/metil_render_pass.h>
 #include <metil_rendering/metil_descriptors/metil_pipeline_render.h>
 #include <metil_rendering/metil_renderable.h>
 #include <metil_rendering/metil_renderable_type.h>
@@ -185,6 +186,11 @@
 
   [
     self
+    descriptor_render_pass_initialize
+  ];
+
+  [
+    self
     descriptor_pipeline_render_initialize
   ];
 
@@ -223,12 +229,20 @@
     &self->mutex_destroying
   );
 
+  (
+    (CAMetalLayer*)
+    metal_kit_view.layer
+  ).maximumDrawableCount = (
+    0x02
+  );
+
   return (
     self
   );
 }
 
-- (void) after_scene_change {}
+- (void) after_scene_change {
+}
 
 - (id<MTLLogState>) log_state_create {
   return (
@@ -395,6 +409,33 @@
 }
 
 - (void) descriptor_render_pass_initialize {
+  if (
+    self->descriptor_render_pass !=
+    0x00
+  ) {
+    [
+      self->descriptor_render_pass
+      release
+    ];
+  }
+
+  self->descriptor_render_pass = [
+    [
+      MTLRenderPassDescriptor
+      alloc
+    ]
+    init
+  ];
+
+  [
+    self->descriptor_render_pass
+    retain
+  ];
+
+  metil_descriptor_render_pass_initialize(
+    self->descriptor_render_pass,
+    self->metil->renderer_interface.metal_device
+  );
 }
 
 - (void) destroy {
@@ -481,6 +522,11 @@
 
   [
     self->command_queue
+    release
+  ];
+
+  [
+    self->descriptor_render_pass
     release
   ];
 
@@ -583,7 +629,8 @@
     state_application >
     0x01
   ) {
-    if (      self->destroying ==
+    if (
+      self->destroying ==
       0x00
     ) {
       struct timespec time_sleep = {
@@ -763,28 +810,10 @@
     release
   ];
 
-  self->descriptor_render_pass = (
-    metal_kit_view.currentRenderPassDescriptor
-  );
-
-  descriptor_render_pass.colorAttachments[
+  self->descriptor_render_pass.colorAttachments[
     0x00
-  ].clearColor = (
-    MTLClearColorMake(
-      (
-        self->metil->rendering_properties.colour_clear.x *
-        self->metil->rendering_properties.brightness
-      ),
-      (
-        self->metil->rendering_properties.colour_clear.y *
-        self->metil->rendering_properties.brightness
-      ),
-      (
-        self->metil->rendering_properties.colour_clear.z *
-        self->metil->rendering_properties.brightness
-      ),
-      self->metil->rendering_properties.colour_clear.w
-    )
+  ].texture = (
+    metal_kit_view.currentDrawable.texture
   );
 
   if (
@@ -794,20 +823,40 @@
     ) ==
     0x00
   ) {
-    descriptor_render_pass.colorAttachments[
+    self->descriptor_render_pass.colorAttachments[
+      0x00
+    ].clearColor = (
+      MTLClearColorMake(
+        (
+          self->metil->rendering_properties.colour_clear.x *
+          self->metil->rendering_properties.brightness
+        ),
+        (
+          self->metil->rendering_properties.colour_clear.y *
+          self->metil->rendering_properties.brightness
+        ),
+        (
+          self->metil->rendering_properties.colour_clear.z *
+          self->metil->rendering_properties.brightness
+        ),
+        self->metil->rendering_properties.colour_clear.w
+      )
+    );
+
+    self->descriptor_render_pass.colorAttachments[
       0x00
     ].loadAction = (
       MTLLoadActionClear
     );
   } else {
-    descriptor_render_pass.colorAttachments[
+    self->descriptor_render_pass.colorAttachments[
       0x00
     ].loadAction = (
       MTLLoadActionLoad
     );
   }
 
-  descriptor_render_pass.colorAttachments[
+  self->descriptor_render_pass.colorAttachments[
     0x00
   ].storeAction = (
     MTLStoreActionStore
@@ -816,7 +865,7 @@
   encoder_render = [
     command_buffer
     renderCommandEncoderWithDescriptor: (
-      descriptor_render_pass
+      self->descriptor_render_pass
     )
   ];
 
@@ -1102,6 +1151,10 @@
   );
 
   self->depth_state_writes_disabled = (
+    0x00
+  );
+
+  self->descriptor_render_pass = (
     0x00
   );
 


### PR DESCRIPTION
- `metil_descriptor_render_pass`:implement_use
- - it actually doesn't need anything but the texture of the current drawable set
- `metil_renderer`
- - set `CAMetalLayer` maximum drawables from `0x03` to `0x02`