### PR TITLE
[dev] `metil_renderer`:reset_drawable_count

### DIFF
--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -229,13 +229,6 @@
     &self->mutex_destroying
   );
 
-  (
-    (CAMetalLayer*)
-    metal_kit_view.layer
-  ).maximumDrawableCount = (
-    0x02
-  );
-
   return (
     self
   );


### PR DESCRIPTION
ran slightly slower with only `0x02` drawables, likely from having to wait for resources to be available again