### PR TITLE
[enh] `metil_editor`:cursor_cursor_movement

### DIFF
--- a/tools/metil_editor/include/metil_editor_player.h
+++ b/tools/metil_editor/include/metil_editor_player.h
@@ -1,0 +1,14 @@
+#ifndef __metil_tools_metil_editor_metil_editor_player_h
+#define __metil_tools_metil_editor_metil_editor_player_h
+
+#include <metil.h>
+#include <metil_player/metil_player.h>
+
+void metil_editor_player_poll_input(
+  struct metil* _Nonnull,
+  struct metil_player* _Nonnull,
+  unsigned long int,
+  unsigned long int
+);
+
+#endif

--- a/tools/metil_editor/sources/metil_editor_player.m
+++ b/tools/metil_editor/sources/metil_editor_player.m
@@ -1,0 +1,59 @@
+#include <metil_editor_player.h>
+
+#include <metil.h>
+#include <metil_player/metil_player.h>
+#include <metil_scenes/metil_scene_controller.h>
+
+void metil_editor_player_poll_input(
+  struct metil* metil,
+  struct metil_player* metil_player,
+  unsigned long int time,
+  unsigned long int time_delta
+) {
+  if (
+    metil->input.keydown_map[
+      metil_keycode_option_left
+    ] !=
+    0x00
+  ) {
+    struct math_c_vector2_float delta_cursor = {
+      .x = (
+        metil->input.cursor.delta.x
+      ),
+      .y = (
+        metil->input.cursor.delta.y
+      )
+    };
+    
+    metil->input.cursor.delta.x = (
+      0x00
+    );
+    
+    metil->input.cursor.delta.y = (
+      0x00
+    );
+    
+    metil_player_poll_input_free_flying_locked(
+      metil,
+      metil_player,
+      time,
+      time_delta
+    );
+    
+    metil->input.cursor.delta.x = (
+      delta_cursor.x
+    );
+    
+    metil->input.cursor.delta.y = (
+      delta_cursor.y
+    );
+  } else {
+    metil_player_poll_input_free_flying_locked(
+      metil,
+      metil_player,
+      time,
+      time_delta
+    );
+  }
+}
+

--- a/tools/metil_editor/sources/metil_editor_player.m
+++ b/tools/metil_editor/sources/metil_editor_player.m
@@ -15,7 +15,7 @@ void metil_editor_player_poll_input(
   struct metil_scene_controller* metil_scene_controller = (
     metil->scene_controller
   );
-  
+
   struct metil_editor_scene_data* metil_editor_scene_data = (
     metil_scene_controller->scene.data
   );
@@ -32,26 +32,26 @@ void metil_editor_player_poll_input(
         metil->input.cursor.delta.y
       )
     };
-    
+
     metil->input.cursor.delta.x = (
       0x00
     );
-    
+
     metil->input.cursor.delta.y = (
       0x00
     );
-    
+
     metil_player_poll_input_free_flying_locked(
       metil,
       metil_player,
       time,
       time_delta
     );
-    
+
     metil->input.cursor.delta.x = (
       delta_cursor.x
     );
-    
+
     metil->input.cursor.delta.y = (
       delta_cursor.y
     );
@@ -64,4 +64,3 @@ void metil_editor_player_poll_input(
     );
   }
 }
-

--- a/tools/metil_editor/sources/metil_editor_player.m
+++ b/tools/metil_editor/sources/metil_editor_player.m
@@ -1,5 +1,7 @@
 #include <metil_editor_player.h>
 
+#include <metil_editor_scene_data.h>
+
 #include <metil.h>
 #include <metil_player/metil_player.h>
 #include <metil_scenes/metil_scene_controller.h>
@@ -10,10 +12,16 @@ void metil_editor_player_poll_input(
   unsigned long int time,
   unsigned long int time_delta
 ) {
+  struct metil_scene_controller* metil_scene_controller = (
+    metil->scene_controller
+  );
+  
+  struct metil_editor_scene_data* metil_editor_scene_data = (
+    metil_scene_controller->scene.data
+  );
+
   if (
-    metil->input.keydown_map[
-      metil_keycode_option_left
-    ] !=
+    metil_editor_scene_data->movement_free ==
     0x00
   ) {
     struct math_c_vector2_float delta_cursor = {

--- a/tools/metil_editor/sources/metil_editor_scene.m
+++ b/tools/metil_editor/sources/metil_editor_scene.m
@@ -654,7 +654,7 @@ void metil_editor_scene_initialize(
   metil_scene->player.position.z = -(
     0x0a
   );
-  
+
   metil_scene->player.rotation.y = (
     math_c_pi_half /
     0x02
@@ -822,7 +822,7 @@ void metil_editor_scene_poll(
     metil,
     metil_scene
   );
-  
+
   struct metil_editor_scene_data* metil_editor_scene_data = (
     metil_scene->data
   );
@@ -856,7 +856,7 @@ void metil_editor_scene_poll(
       metil_editor_scene_index_renderable_cursor
     ].renderable
   );
-  
+
   if (
     (
       metil->input.keydown_map[
@@ -1330,11 +1330,11 @@ void metil_editor_scene_poll(
     metil_scene->player.position = (
       metil_editor_scene_data->position_player
     );
-    
+
     float multiplier = (
       0x01
     );
-    
+
     if (
       (
         metil->input.keydown_map[
@@ -1354,7 +1354,7 @@ void metil_editor_scene_poll(
         0x02
       );
     }
-    
+
     if (
       metil->input.keydown_map[
         metil_keycode_control
@@ -1366,14 +1366,14 @@ void metil_editor_scene_poll(
         0x04
       );
     }
-    
+
     metil_object_cursor->position.x = (
       metil_object_cursor->position.x +
       metil->input.cursor.delta.x /
       0x64 *
       multiplier
     );
-  
+
     if (
       metil->input.keydown_map[
         metil_keycode_option_left
@@ -1394,11 +1394,11 @@ void metil_editor_scene_poll(
         multiplier
       );
     }
-  
+
     metil->input.cursor.delta.x = (
       0x00
     );
-  
+
     metil->input.cursor.delta.y = (
       0x00
     );

--- a/tools/metil_editor/sources/metil_editor_scene.m
+++ b/tools/metil_editor/sources/metil_editor_scene.m
@@ -2,6 +2,7 @@
 
 #include <metil_editor_index_pipeline_render.h>
 #include <metil_editor_paths.h>
+#include <metil_editor_player.h>
 #include <metil_editor_scene_data.h>
 
 #include <clic3_bytes.h>
@@ -653,14 +654,14 @@ void metil_editor_scene_initialize(
   metil_scene->player.position.z = -(
     0x0a
   );
-
-  metil_scene->player.poll_input = (
-    metil_player_poll_input_free_flying_locked
-  );
-
+  
   metil_scene->player.rotation.y = (
     math_c_pi_half /
     0x02
+  );
+
+  metil_scene->player.poll_input = (
+    metil_editor_player_poll_input
   );
 
   metil_editor_scene_data->movement_free = (
@@ -1333,6 +1334,35 @@ void metil_editor_scene_poll(
     metil_editor_scene_data->position_player = (
       metil_scene->player.position
     );
+  }
+  
+  metil_object_cursor->position.x = (
+   metil_object_cursor->position.x +
+    metil->input.cursor.delta.x /
+    0x64
+  );
+  
+  metil_object_cursor->position.y = (
+    metil_object_cursor->position.y +
+    metil->input.cursor.delta.y /
+    0x64
+  );
+  
+  metil->input.cursor.delta.x = (
+    0x00
+  );
+  
+  metil->input.cursor.delta.y = (
+    0x00
+  );
+  
+  if (
+    metil->input.keydown_map[
+      metil_keycode_control
+    ] !=
+    0x00
+  ) {
+    printf("%f\n",metil->input.cursor.delta.y);
   }
 
   metil_object_cursor->mesh.size.x = (

--- a/tools/metil_editor/sources/metil_editor_scene.m
+++ b/tools/metil_editor/sources/metil_editor_scene.m
@@ -1330,39 +1330,82 @@ void metil_editor_scene_poll(
     metil_scene->player.position = (
       metil_editor_scene_data->position_player
     );
+    
+    float multiplier = (
+      0x01
+    );
+    
+    if (
+      (
+        metil->input.keydown_map[
+          metil_keycode_shift_left
+        ]
+      ) !=
+      0x00 ||
+      (
+        metil->input.keydown_map[
+          metil_keycode_shift_right
+        ] !=
+        0x00
+      )
+    ) {
+      multiplier = (
+        multiplier *
+        0x02
+      );
+    }
+    
+    if (
+      metil->input.keydown_map[
+        metil_keycode_control
+      ] !=
+      0x00
+    ) {
+      multiplier = (
+        multiplier /
+        0x04
+      );
+    }
+    
+    metil_object_cursor->position.x = (
+      metil_object_cursor->position.x +
+      metil->input.cursor.delta.x /
+      0x64 *
+      multiplier
+    );
+  
+    if (
+      metil->input.keydown_map[
+        metil_keycode_option_left
+      ] !=
+      0x00
+    ) {
+      metil_object_cursor->position.y = (
+        metil_object_cursor->position.y -
+        metil->input.cursor.delta.y /
+        0x64 *
+        multiplier
+       );
+    } else {
+      metil_object_cursor->position.z = (
+        metil_object_cursor->position.z -
+        metil->input.cursor.delta.y /
+        0x64 *
+        multiplier
+      );
+    }
+  
+    metil->input.cursor.delta.x = (
+      0x00
+    );
+  
+    metil->input.cursor.delta.y = (
+      0x00
+    );
   } else {
     metil_editor_scene_data->position_player = (
       metil_scene->player.position
     );
-  }
-  
-  metil_object_cursor->position.x = (
-   metil_object_cursor->position.x +
-    metil->input.cursor.delta.x /
-    0x64
-  );
-  
-  metil_object_cursor->position.y = (
-    metil_object_cursor->position.y +
-    metil->input.cursor.delta.y /
-    0x64
-  );
-  
-  metil->input.cursor.delta.x = (
-    0x00
-  );
-  
-  metil->input.cursor.delta.y = (
-    0x00
-  );
-  
-  if (
-    metil->input.keydown_map[
-      metil_keycode_control
-    ] !=
-    0x00
-  ) {
-    printf("%f\n",metil->input.cursor.delta.y);
   }
 
   metil_object_cursor->mesh.size.x = (


### PR DESCRIPTION
- `metil_editor`:allow_cursor_to_move_the_cursor
- - if not in `movement_free` mode allow cursor movement from the cursor
- - movement values
- - - cursor delta `x` moves cursor position `x`
- - - cursor delta `y` moves cursor position `z` if `option` is not held otherwise moves cursor position `y`
- - movement modifiers
- - - shift multiplies movement value by `0x02`
- - - control divides movement value by `0x04`


https://github.com/user-attachments/assets/16bd37d6-3c11-429e-93ec-69199db17162

