### PR TITLE
[enh] ios_background_rendering_simplification

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -68,11 +68,6 @@
 
   @public metil_renderer_data_frame_poll_function poll_data_frame;
 
-  #if target_os_ios
-  unsigned char state_application_previous;
-  unsigned long int time_state_application_inactive;
-  #endif
-
   unsigned char destroying;
   pthread_mutex_t mutex_destroying;
 }

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -760,47 +760,13 @@
     applicationState
   ];
 
-  if (
-    self->state_application_previous !=
-    state_application
-  ) {
-    self->state_application_previous = (
-      state_application
-    );
-
-    if (
-      state_application !=
-      0x00
-    ) {
-      self->time_state_application_inactive = (
-        self->metil->rendering_properties.time_frames[
-          metil_count_time_frames -
-          0x01
-        ]
-      );
-    }
-  }
-
   unsigned char ios_render = (
     (
-      state_application ==
-      0x00
+      state_application <
+      0x02
     )
     ? 0x01
-    : (
-      (
-        (
-          self->metil->rendering_properties.time_frames[
-            metil_count_time_frames -
-            0x01
-          ] -
-          self->time_state_application_inactive
-        ) <
-        0x2710
-      )
-      ? 0x01
-      : 0x00
-    )
+    : 0x00
   );
   #endif
 
@@ -1197,16 +1163,6 @@
   self->length_threads = (
     0x00
   );
-
-  #if target_os_ios
-  self->state_application_previous = (
-    0xff
-  );
-
-  self->time_state_application_inactive = (
-    0x00
-  );
-  #endif
 
   self->poll_data_frame = (
     metil_renderer_data_frame_poll


### PR DESCRIPTION
- remove previous state application
- remove time state application inactive
- dont render if state of application is background otherwise render
- - keep rendering if state of application is inactive or active
- - - prevents screen blanking when switching applications
- - - makes screen appearance fluid when switching between applications
- - - continues rendering while switching
- - - when in background system keeps last rendered frame as apps visual when switching