### PR TITLE
[enh] `metil_object`:additional_destroy_functions

### DIFF
--- a/include/metil_object/metil_object.h
+++ b/include/metil_object/metil_object.h
@@ -118,4 +118,39 @@ void metil_object_destroy_with_textures(
   struct metil_object* _Nonnull
 );
 
+void metil_object_destroy_without_buffers(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_vertices_buffer(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_indices_vertices_buffers(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_data_buffer(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_data_vertices_buffers(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_vertex_buffers(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_fragment_buffers(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
 #endif

--- a/sources/metil_object/metil_object.m
+++ b/sources/metil_object/metil_object.m
@@ -483,3 +483,127 @@ void metil_object_destroy_with_textures(
     metil_object
   );
 }
+
+void metil_object_destroy_without_buffers(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object->indices = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_vertices_buffer(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_vertex[
+    metil_object_buffer_default_index_vertices
+  ].buffer = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_indices_vertex_buffers(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_vertex[
+    metil_object_buffer_default_index_vertices
+  ].buffer = (
+    0x00
+  );
+
+  metil_object->indices = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_data_buffer(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_vertex[
+    metil_object_buffer_default_index_data
+  ].buffer = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_data_vertices_buffers(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_vertex[
+    metil_object_buffer_default_index_data
+  ].buffer = (
+    0x00
+  );
+
+  metil_object->buffers_vertex[
+    metil_object_buffer_default_index_vertices
+  ].buffer = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_vertex_buffers(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_fragment_buffers(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}


### PR DESCRIPTION
- `metil_object`:additional_destroy_functions
- - `metil_object_destroy_without_buffers`
- - - destroy `metil_object` without releasing any buffers (fragment, indices, vertex)
- - `metil_object_destroy_without_vertices_buffer`
- - - destroy `metil_object` without releasing the vertices buffer
- - `metil_object_destroy_without_indices_vertices_buffers`
- - - destroy `metil_object` without releasing the indices buffer or the vertices buffer
- - `metil_object_destroy_without_data_buffer`
- - - destroy `metil_object` without releasing the data buffer
- - `metil_object_destroy_without_data_vertices_buffers`
- - - destroy `metil_object` without releasing the data buffer or vertices buffer
- - `metil_object_destroy_without_vertex_buffers`
- - - destroy `metil_object` without releasing any vertex buffers
- - `metil_object_destroy_without_fragment_buffers`
- - - destroy `metil_object` without releasing any fragment buffers

i use equivalents of these often so adding them into `metil`