### PR TITLE
[dev] `metil_object`:add->{`metil_object_initialize_deallocated`};

### DIFF
--- a/include/metil_object/metil_object.h
+++ b/include/metil_object/metil_object.h
@@ -67,6 +67,10 @@ void metil_object_initialize(
   struct metil_object* _Nonnull
 );
 
+void metil_object_initialize_deallocated(
+  struct metil_object* _Nonnull
+);
+
 void metil_object_indices_initialize(
   struct metil_object* _Nonnull,
   _Nonnull id<MTLDevice>

--- a/sources/metil_object/metil_object.m
+++ b/sources/metil_object/metil_object.m
@@ -18,12 +18,8 @@
 void metil_object_initialize(
   struct metil_object* metil_object
 ) {
-  metil_object->length_buffers_fragment = (
-    0x00
-  );
-
-  metil_object->length_buffers_vertex = (
-    0x00
+  metil_object_initialize_deallocated(
+    metil_object
   );
 
   metil_object->buffers_fragment = (
@@ -36,6 +32,32 @@ void metil_object_initialize(
     clic3_memory_allocate_raw(
       0x00
     )
+  );
+
+  metil_object->textures = (
+    clic3_memory_allocate_raw(
+      0x00
+    )
+  );
+}
+
+void metil_object_initialize_deallocated(
+  struct metil_object* metil_object
+) {
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object->buffers_fragment = (
+    0x00
+  );
+
+  metil_object->buffers_vertex = (
+    0x00
   );
 
   metil_object->indices = (
@@ -55,9 +77,7 @@ void metil_object_initialize(
   );
 
   metil_object->textures = (
-    clic3_memory_allocate_raw(
-      0x00
-    )
+    0x00
   );
 
   metil_object->position.x = (


### PR DESCRIPTION
- `metil_object_initialize_deallocated`
- - initialization function that doesnt allocate `buffers_fragment`, `buffers_vertex`, or `textures`
- - makes it a bit easier to have objects which share buffers
- - - can just set one of the aforementioned properties on object_b to one on object_a