### PR TITLE
[enh] `metil_object`:add->{`metil_object_destroy_without_deallocating%`:functions};

### DIFF
--- a/include/metil_object/metil_object.h
+++ b/include/metil_object/metil_object.h
@@ -157,4 +157,39 @@ void metil_object_destroy_without_fragment_buffers(
   struct metil_object* _Nonnull
 );
 
+void metil_object_destroy_without_deallocating(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_deallocating_buffers(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_deallocating_buffers_fragment(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_deallocating_buffers_vertex(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_deallocating_textures(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_deallocating_buffers_fragment_textures(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
+void metil_object_destroy_without_deallocating_buffers_vertex_textures(
+  struct metil* _Nonnull,
+  struct metil_object* _Nonnull
+);
+
 #endif

--- a/sources/metil_object/metil_object.m
+++ b/sources/metil_object/metil_object.m
@@ -627,3 +627,169 @@ void metil_object_destroy_without_fragment_buffers(
     metil_object
   );
 }
+
+void metil_object_destroy_without_deallocating(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_fragment = (
+    0x00
+  );
+
+  metil_object->buffers_vertex = (
+    0x00
+  );
+
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object->textures = (
+    0x00
+  );
+
+  metil_object->length_textures = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_deallocating_buffers(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_fragment = (
+    0x00
+  );
+
+  metil_object->buffers_vertex = (
+    0x00
+  );
+
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_deallocating_buffers_fragment(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_fragment = (
+    0x00
+  );
+
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_deallocating_buffers_vertex(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_vertex = (
+    0x00
+  );
+
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_deallocating_textures(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->textures = (
+    0x00
+  );
+
+  metil_object->length_textures = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_deallocating_buffers_fragment_textures(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_fragment = (
+    0x00
+  );
+
+  metil_object->length_buffers_fragment = (
+    0x00
+  );
+
+  metil_object->textures = (
+    0x00
+  );
+
+  metil_object->length_textures = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}
+
+void metil_object_destroy_without_deallocating_buffers_vertex_textures(
+  struct metil* metil,
+  struct metil_object* metil_object
+) {
+  metil_object->buffers_vertex = (
+    0x00
+  );
+
+  metil_object->length_buffers_vertex = (
+    0x00
+  );
+
+  metil_object->textures = (
+    0x00
+  );
+
+  metil_object->length_textures = (
+    0x00
+  );
+
+  metil_object_destroy(
+    metil,
+    metil_object
+  );
+}


### PR DESCRIPTION
- `metil_object`:add->{`metil_object_destroy_without_deallocating%`:functions};
- - `metil_object_destroy_without_deallocating`
- - - destroy `metil_object` without releasing fragment buffers or vertex buffers or textures or deallocating buffers fragment or buffers vertex or textures properties
- - `metil_object_destroy_without_deallocating_buffers`
- - - destroy `metil_object` without releasing fragment buffers or vertex buffers or deallocating buffers fragment or buffers vertex properties
- - `metil_object_destroy_without_deallocating_buffers_fragment`
- - - destroy `metil_object` without releasing fragment buffers or deallocating buffers fragment property
- - `metil_object_destroy_without_deallocating_buffers_vertex`
- - - destroy `metil_object` without releasing vertex buffers or deallocating buffers vertex property
- - `metil_object_destroy_without_deallocating_textures`
- - - destroy `metil_object` without releasing textures or deallocating textures property
- - `metil_object_destroy_without_deallocating_buffers_fragment_textures`
- - - destroy `metil_object` without releasing fragment buffers or textures or deallocating buffers fragment or textures property
- - `metil_object_destroy_without_deallocating_buffers_vertex_textures`
- - - destroy `metil_object` without releasing vertex buffers or textures or deallocating buffers vertex textures property