### PR TITLE
[enh] Metil filtering repeats double textures

### DIFF
--- a/examples/filter/metal/filter.metal
+++ b/examples/filter/metal/filter.metal
@@ -21,21 +21,52 @@ kernel void filter_compute(
   
     float4 j = texture.read(
       ushort2(
-        (l.y + 100) % texture.get_width(),
-        (l.y + 100) % texture.get_height()
+        (l.x * 0x2) % texture.get_width(),
+        (l.y * 0x2) % texture.get_height()
       )
     );
     
-    float4 q = texture.read(
-      l
+    float4 r = texture.read(
+      ushort2(
+        (l.x * 0x8) % texture.get_width(),
+        (l.y * 0x8) % texture.get_height()
+      )
     );
+    
+    float4 q = ( j * r* texture.read(
+      l
+    ));
+    
+    q.w = 1;
+    
+    if (
+      q.x > 0x01
+    ) {
+      q.x = (
+        q.x - 1
+      );
+      }
+      
+      if (
+      q.y > 0x01
+    ) {
+      q.y = (
+        q.y - 1
+      );
+      }
+      
+      if (
+      q.z > 0x01
+    ) {
+      q.z = (
+        q.z - 1
+      );
+      }
 
     texture.write(
       (
-        texture.read(
-          l
-        ) *
-        float4(0,1,1,1)
+        q*
+        float4(0.3,1,1,1)
       ),
      l,
     0

--- a/examples/filter/metal/filter.metal
+++ b/examples/filter/metal/filter.metal
@@ -8,6 +8,11 @@ kernel void filter_compute(
       0x00
     )
   ]],
+  metal::texture2d<float, metal::access::read_write> texture_output [[
+    texture(
+      0x01
+    )
+  ]],
   unsigned int index[[
     thread_position_in_grid
   ]]
@@ -63,7 +68,7 @@ kernel void filter_compute(
       );
       }
 
-    texture.write(
+    texture_output.write(
       (
         q*
         float4(0.3,1,1,1)

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -55,6 +55,7 @@
   
   id<MTLComputePipelineState> pipeline_state_compute;
   id<MTLTexture> texture_render;
+  id<MTLTexture> texture_render_filtered;
   MTLTextureDescriptor* descriptor_texture_render;
   unsigned short int index_pipeline_render_texture;
   id<MTLBuffer> indices_render;

--- a/metal/filter.metal
+++ b/metal/filter.metal
@@ -21,21 +21,52 @@ kernel void filter_compute(
   
     float4 j = texture.read(
       ushort2(
-        (l.y + 100) % texture.get_width(),
-        (l.y + 100) % texture.get_height()
+        (l.x * 0x2) % texture.get_width(),
+        (l.y * 0x2) % texture.get_height()
       )
     );
     
-    float4 q = texture.read(
-      l
+    float4 r = texture.read(
+      ushort2(
+        (l.x * 0x8) % texture.get_width(),
+        (l.y * 0x8) % texture.get_height()
+      )
     );
+    
+    float4 q = ( j * r* texture.read(
+      l
+    ));
+    
+    q.w = 1;
+    
+    if (
+      q.x > 0x01
+    ) {
+      q.x = (
+        q.x - 1
+      );
+      }
+      
+      if (
+      q.y > 0x01
+    ) {
+      q.y = (
+        q.y - 1
+      );
+      }
+      
+      if (
+      q.z > 0x01
+    ) {
+      q.z = (
+        q.z - 1
+      );
+      }
 
     texture.write(
       (
-        texture.read(
-          l
-        ) *
-        float4(0,1,1,1)
+        q*
+        float4(0.3,1,1,1)
       ),
      l,
     0

--- a/metal/filter.metal
+++ b/metal/filter.metal
@@ -8,6 +8,11 @@ kernel void filter_compute(
       0x00
     )
   ]],
+  metal::texture2d<float, metal::access::read_write> texture_output [[
+    texture(
+      0x01
+    )
+  ]],
   unsigned int index[[
     thread_position_in_grid
   ]]
@@ -63,7 +68,7 @@ kernel void filter_compute(
       );
       }
 
-    texture.write(
+    texture_output.write(
       (
         q*
         float4(0.3,1,1,1)

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -815,6 +815,13 @@
       )
     ];
     
+    self->texture_render_filtered = [
+      self->metil->renderer_interface.metal_device
+      newTextureWithDescriptor: (
+        self->descriptor_texture_render
+      )
+    ];
+    
     self->index_pipeline_render_texture = [
       metil->renderer_interface.renderer
       pipeline_add: [
@@ -849,7 +856,6 @@
     0x00
   ].texture = (
     self->texture_render
-    //metal_kit_view.currentDrawable.texture
   );
 
   #if target_os_ios
@@ -1120,6 +1126,14 @@
         
         [
           j
+          setTexture: (
+            self->texture_render_filtered
+          )
+          atIndex: 0x01
+        ];
+        
+        [
+          j
           dispatchThreads: (
             MTLSizeMake(self->texture_render.height * self->texture_render.width, 1, 1)
           )
@@ -1183,7 +1197,7 @@
           [
             encoder_render
             setFragmentTexture: (
-              self->texture_render
+              self->texture_render_filtered
             )
             atIndex: 0x00
           ];


### PR DESCRIPTION
use input output textures to prevent thread overlapping



https://github.com/user-attachments/assets/71b5f939-ea01-4ed3-8521-e78a3f8188b7


