### PR TITLE
[dev] `metil_renderer`:remove_after_scene_change_functions

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -76,8 +76,6 @@
   (nonnull MTKView*) metal_kit_view
   metil: (nonnull struct metil*) parameter_metil;
 
-- (void) after_scene_change;
-
 - (id<MTLLogState> _Nullable) log_state_create;
 
 - (void) command_queue_initialize;
@@ -154,12 +152,6 @@ void* _Nullable metil_renderer_thread_draw(
 #endif
 
 void* _Nullable metil_renderer_thread_poll_object(
-  void* _Nonnull
-);
-
-void metil_renderer_after_scene_change(
-  struct metil* _Nonnull,
-  int,
   void* _Nonnull
 );
 

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -158,12 +158,6 @@
     &self->metil->text_defaults.render_parameters
   );
 
-  metil_scene_controller_after_scene_change_add(
-    self->metil->scene_controller,
-    metil_renderer_after_scene_change,
-    self
-  );
-
   [
     self
     command_queue_initialize
@@ -232,9 +226,6 @@
   return (
     self
   );
-}
-
-- (void) after_scene_change {
 }
 
 - (id<MTLLogState>) log_state_create {
@@ -2438,21 +2429,6 @@ void* metil_renderer_thread_poll_object(
   return (
     0x00
   );
-}
-
-void metil_renderer_after_scene_change(
-  struct metil* metil,
-  int id_scene,
-  void* reference
-) {
-  metil_renderer* renderer = (
-    reference
-  );
-
-  [
-    renderer
-    after_scene_change
-  ];
 }
 
 void metil_renderer_on_termination(


### PR DESCRIPTION
- `metil_renderer`:remove_after_scene_change_functions
- - this wasn't ever used for anything so..