### PR TITLE
[enh] `metil_renderer`:indirect_rendering

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -29,6 +29,11 @@
 #define metil_renderer_pipelines_render_index_fps_display 0x01
 #define metil_renderer_pipelines_render_index_wireframe 0x02
 
+typedef unsigned char (*metil_renderer_after_render_function)(
+  struct metil* _Nonnull,
+  unsigned int
+);
+
 @interface metil_renderer : NSObject<MTKViewDelegate> {
   struct metil* metil;
 
@@ -70,6 +75,7 @@
   matrix_float3x4 matrix_projection_static;
 
   @public metil_renderer_data_frame_poll_function poll_data_frame;
+  @public metil_renderer_after_render_function after_render;
 
   unsigned char destroying;
   pthread_mutex_t mutex_destroying;

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -60,6 +60,9 @@
   unsigned short int length_pipelines_render;
   unsigned short int index_pipelines_render_current;
 
+  id<MTLTexture> texture_render_target;
+  id<MTLTexture> texture_render_processed;
+
   pthread_t* threads;
   struct metil_renderer_thread_poll_object_data* threads_data;
   unsigned int length_threads;

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -61,7 +61,7 @@
   unsigned short int index_pipelines_render_current;
 
   id<MTLTexture> texture_render_target;
-  id<MTLTexture> texture_render_processed;
+  id<MTLTexture> texture_render_target_processed;
 
   pthread_t* threads;
   struct metil_renderer_thread_poll_object_data* threads_data;

--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -65,8 +65,8 @@ typedef unsigned char (*metil_renderer_after_render_function)(
   unsigned short int length_pipelines_render;
   unsigned short int index_pipelines_render_current;
 
-  id<MTLTexture> texture_render_target;
-  id<MTLTexture> texture_render_target_processed;
+  @public id<MTLTexture> texture_render_target;
+  @public id<MTLTexture> texture_render_target_processed;
 
   pthread_t* threads;
   struct metil_renderer_thread_poll_object_data* threads_data;

--- a/include/metil_rendering/metil_rendering_properties.h
+++ b/include/metil_rendering/metil_rendering_properties.h
@@ -13,9 +13,10 @@
 #define metil_count_time_frames 0x3c
 
 enum metil_rendering_properties_mode {
-  metil_rendering_properties_mode_default        = 0b0001,
-  metil_rendering_properties_mode_wireframe      = 0b0010,
-  metil_rendering_properties_mode_wireframe_full = 0b0100
+  metil_rendering_properties_mode_default            = 0b0001,
+  metil_rendering_properties_mode_wireframe          = 0b0010,
+  metil_rendering_properties_mode_wireframe_full     = 0b0100,
+  metil_rendering_properties_mode_indirect_rendering = 0b1000
 };
 
 enum metil_rendering_properties_disables {

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -475,11 +475,6 @@
     self->threads_data
   );
 
-  [
-    self->metil->renderer_interface.metal_device
-    release
-  ];
-
   for (
     unsigned char index_data_buffer_frame_release = (
       0x00
@@ -584,6 +579,31 @@
   metil_rendering_properties_destory(
     &self->metil->rendering_properties
   );
+  
+  if (
+    self->texture_render_target !=
+    0x00
+  ) {
+    [
+      self->texture_render_target
+      release
+    ];
+  }
+  
+  if (
+    self->texture_render_target_processed !=
+    0x00
+  ) {
+    [
+      self->texture_render_target_processed
+      release
+    ];
+  }
+  
+  [
+    self->metil->renderer_interface.metal_device
+    release
+  ];
 }
 
 - (void) drawInMTKView: (nonnull MTKView*) metal_kit_view {
@@ -1227,6 +1247,14 @@
       0x00
     );
   }
+  
+  self->texture_render_target = (
+    0x00
+  );
+  
+  self->texture_render_target_processed = (
+    0x00
+  );
 }
 
 - (void) mtkView:
@@ -1352,7 +1380,7 @@
     self->descriptor_pipeline_render.fragmentFunction = (
       function_fragment
     );
-
+    
     self->descriptor_pipeline_render.vertexFunction = (
       function_vertex
     );
@@ -1428,7 +1456,7 @@
   struct metil_player* metil_player = &(
     metil_scene->player
   );
-
+  
   unsigned char disabled_polling = (
     self->metil->rendering_properties.disables &
     metil_rendering_properties_disables_polling
@@ -1523,7 +1551,7 @@
         rotation_cosine.y,
         0x00,
         rotation_sine.y,
-        0x00
+        0x00  
       },
       {
         0x00,
@@ -1999,7 +2027,7 @@
           )
         ];
       }
-
+      
       break;
     }
     case metil_renderable_type_menu: {
@@ -2060,7 +2088,7 @@
           ];
         }
       }
-
+      
       break;
     }
     default: {

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -752,11 +752,25 @@
     release
   ];
 
-  self->descriptor_render_pass.colorAttachments[
+  if (
+    (
+      self->metil->rendering_properties.mode &
+      metil_rendering_properties_mode_indirect_rendering
+    ) ==
     0x00
-  ].texture = (
-    metal_kit_view.currentDrawable.texture
-  );
+  ) {
+    self->descriptor_render_pass.colorAttachments[
+      0x00
+    ].texture = (
+      metal_kit_view.currentDrawable.texture
+    );
+  } else {
+    self->descriptor_render_pass.colorAttachments[
+      0x00
+    ].texture = (
+      self->texture_render_target
+    );
+  }
 
   #if target_os_ios
   metil_application* metil_ui_application = (
@@ -989,12 +1003,20 @@
     }
   ];
 
-  [
-    command_buffer
-    presentDrawable: (
-      metal_kit_view.currentDrawable
-    )
-  ];
+  if (
+    (
+      self->metil->rendering_properties.mode &
+      metil_rendering_properties_mode_indirect_rendering
+    ) ==
+    0x00
+  ) {
+    [
+      command_buffer
+      presentDrawable: (
+        metal_kit_view.currentDrawable
+      )
+    ];
+  }
 
   [
     command_buffer

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -579,7 +579,7 @@
   metil_rendering_properties_destory(
     &self->metil->rendering_properties
   );
-  
+
   if (
     self->texture_render_target !=
     0x00
@@ -589,7 +589,7 @@
       release
     ];
   }
-  
+
   if (
     self->texture_render_target_processed !=
     0x00
@@ -599,7 +599,7 @@
       release
     ];
   }
-  
+
   [
     self->metil->renderer_interface.metal_device
     release
@@ -986,11 +986,11 @@
         self->metil->rendering_properties.count_completed_frames +
         0x01
       );
-      
+
       unsigned char continue_rendering = (
         0x01
       );
-      
+
       if (
         self->after_render !=
         0x00
@@ -1000,7 +1000,7 @@
             self->metil,
             index_frame
           )
-        );  
+        );
       }
 
       if (
@@ -1290,15 +1290,15 @@
       0x00
     );
   }
-  
+
   self->texture_render_target = (
     0x00
   );
-  
+
   self->texture_render_target_processed = (
     0x00
   );
-  
+
   self->after_render = (
     0x00
   );
@@ -1427,7 +1427,7 @@
     self->descriptor_pipeline_render.fragmentFunction = (
       function_fragment
     );
-    
+
     self->descriptor_pipeline_render.vertexFunction = (
       function_vertex
     );
@@ -1503,7 +1503,7 @@
   struct metil_player* metil_player = &(
     metil_scene->player
   );
-  
+
   unsigned char disabled_polling = (
     self->metil->rendering_properties.disables &
     metil_rendering_properties_disables_polling
@@ -1598,7 +1598,7 @@
         rotation_cosine.y,
         0x00,
         rotation_sine.y,
-        0x00  
+        0x00
       },
       {
         0x00,
@@ -2074,7 +2074,7 @@
           )
         ];
       }
-      
+
       break;
     }
     case metil_renderable_type_menu: {
@@ -2135,7 +2135,7 @@
           ];
         }
       }
-      
+
       break;
     }
     default: {

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -986,15 +986,36 @@
         self->metil->rendering_properties.count_completed_frames +
         0x01
       );
+      
+      unsigned char continue_rendering = (
+        0x01
+      );
+      
+      if (
+        self->after_render !=
+        0x00
+      ) {
+        continue_rendering = (
+          self->after_render(
+            self->metil,
+            index_frame
+          )
+        );  
+      }
 
       if (
         self->destroying ==
         0x00
       ) {
-        [
-          metal_kit_view
-          draw
-        ];
+        if (
+          continue_rendering !=
+          0x00
+        ) {
+          [
+            metal_kit_view
+            draw
+          ];
+        }
       } else {
         pthread_mutex_unlock(
           &self->mutex_destroying
@@ -1275,6 +1296,10 @@
   );
   
   self->texture_render_target_processed = (
+    0x00
+  );
+  
+  self->after_render = (
     0x00
   );
 }


### PR DESCRIPTION
- `metil_rendering_properties_mode_indirect_rendering`:add
- `metil_renderer`
- - add->{`texture_render_target`};
- - - indirect rendering mode requires this to be allocated and initialized
- - add->{`texture_render_target_processed`};
- - - currently unused
- - add conditional checks for indirect rendering
- - add->{`after_render`}
- - - function called once rendering has completed
- - - - called regardless of direct or indirect rendering modes
- - - - passed `metil` and `index_frame`
- - - - return value of `0x00` stops further rendering (a call to `[metal_kit_view draw]` will have to be made to resume rendering, `0x01` continues rendering

this implements an initial indirect rendering mode. allowing renders to be drawn into a specified texture rather than presented on screen. this allows for things such as implementing an application which renders 3d scenes in the background and then outputs them to a video file, for example.