### PR TITLE
[enh] `metil_renderer`:set_texture_render_targets_to_public

### DIFF
--- a/include/metil_rendering/metil_renderer.h
+++ b/include/metil_rendering/metil_renderer.h
@@ -65,8 +65,8 @@ typedef unsigned char (*metil_renderer_after_render_function)(
   unsigned short int length_pipelines_render;
   unsigned short int index_pipelines_render_current;
 
-  id<MTLTexture> texture_render_target;
-  id<MTLTexture> texture_render_target_processed;
+  @public id<MTLTexture> texture_render_target;
+  @public id<MTLTexture> texture_render_target_processed;
 
   pthread_t* threads;
   struct metil_renderer_thread_poll_object_data* threads_data;


### PR DESCRIPTION
- `metil_renderer`:set_texture_render_targets_to_public
- - for easier access to read/writes/setting of this property