### PR TITLE
[dev] metil_filtering_multiple_filter_support

### DIFF
--- a/examples/filter/metal/metil_example_filter.metal
+++ b/examples/filter/metal/metil_example_filter.metal
@@ -35,7 +35,7 @@ kernel void metil_example_filter_compute(
       )
     )
   );
-  
+
   float4 j = (
     texture.read(
       ushort2(
@@ -44,7 +44,7 @@ kernel void metil_example_filter_compute(
       )
     )
   );
-  
+
   float4 r = (
     texture.read(
       ushort2(
@@ -53,7 +53,7 @@ kernel void metil_example_filter_compute(
       )
     )
   );
-    
+
   float4 q = (
     j *
     r *
@@ -61,11 +61,11 @@ kernel void metil_example_filter_compute(
       l
     )
   );
-  
+
   q.w = (
     0x01
   );
-  
+
   while (
     q.x >
     0x01
@@ -75,7 +75,7 @@ kernel void metil_example_filter_compute(
       0x01
     );
   }
-  
+
   while (
     q.y >
     0x01
@@ -85,7 +85,7 @@ kernel void metil_example_filter_compute(
       0x01
     );
   }
-  
+
   while (
     q.z >
     0x01
@@ -97,15 +97,63 @@ kernel void metil_example_filter_compute(
   }
 
   texture_output.write(
-    (
-      q *
-      float4(
-        0.3,
-        0x01,
-        0x01,
-        0x01
+    q,
+    l,
+    0x00
+  );
+}
+
+kernel void metil_example_filter_second_compute(
+  metal::texture2d<
+    float,
+    metal::access::read_write
+  > texture [[
+    texture(
+      0x00
+    )
+  ]],
+  metal::texture2d<
+    float,
+    metal::access::read_write
+  > texture_output [[
+    texture(
+      0x01
+    )
+  ]],
+  unsigned int index[[
+    thread_position_in_grid
+  ]]
+) {
+  ushort2 l = (
+    ushort2(
+      (
+        index %
+        texture.get_width()
+      ),
+      (
+        index /
+        texture.get_width()
       )
-    ),
+    )
+  );
+
+  float4 q = (
+    texture.read(
+      l
+    )
+  );
+
+  q = (
+    0x01 -
+    q
+  );
+
+  q.w = (
+    0x01
+  );
+
+  texture_output.write(
+    q,
     l,
     0x00
   );

--- a/examples/filter/metal/metil_example_filter_object.metal
+++ b/examples/filter/metal/metil_example_filter_object.metal
@@ -74,7 +74,7 @@ struct data_vertex {
       data_object->colour.w
     )
   );
-  
+
   data_vertex.brightness = (
     (
       vertices[

--- a/examples/filter/sources/metil_example_filter.m
+++ b/examples/filter/sources/metil_example_filter.m
@@ -33,7 +33,7 @@ void metil_example_filter_renderer_on_initialize(
       )
     )
   );
-  
+
   struct metil_example_filter_pipeline_index* metil_example_filter_pipeline_index = (
     metil->data
   );
@@ -44,7 +44,7 @@ void metil_example_filter_renderer_on_initialize(
     @"metil_example_filter_object_fragment",
     @"metil_example_filter_object_vertex"
   );
-  
+
   metil_example_filter_pipeline_index->compute = (
     0x00
   );
@@ -60,7 +60,7 @@ void metil_example_filter_renderer_on_initialize(
       newFunctionWithName: @"metil_example_filter_fog_vertex"
     ]
   ];
-  
+
   metil->rendering_properties.index_pipeline_render_texture = [
     metil->renderer_interface.renderer
     pipeline_add: [
@@ -72,17 +72,17 @@ void metil_example_filter_renderer_on_initialize(
       newFunctionWithName: @"metil_indirect_rendering_vertex"
     ]
   ];
-  
+
   metil->rendering_properties.mode = (
     metil_rendering_properties_mode_default |
     metil_rendering_properties_mode_filters_automatic
   );
-  
+
   struct metil_filter* metil_filter = [
     metil->renderer_interface.renderer
     filter_add
   ];
-  
+
   metil_filter_initialize(
     metil_filter,
     [
@@ -96,7 +96,26 @@ void metil_example_filter_renderer_on_initialize(
     ],
     0x00
   );
-  
+
+  metil_filter = [
+    metil->renderer_interface.renderer
+    filter_add
+  ];
+
+  metil_filter_initialize(
+    metil_filter,
+    [
+      metil->renderer_interface.renderer
+      pipeline_compute_add: (
+        [
+          metil->library.library
+          newFunctionWithName: @"metil_example_filter_second_compute"
+        ]
+      )
+    ],
+    0x00
+  );
+
   struct metil_scene_controller* metil_scene_controller = (
     metil->scene_controller
   );

--- a/metal/metil_indirect_rendering.metal
+++ b/metal/metil_indirect_rendering.metal
@@ -21,14 +21,14 @@
           0x01
         )
       );
-      
+
       data_vertex_basic_textured_coloured.position_texture = (
         float2(
           0x00,
           0x01
         )
       );
-      
+
       break;
     }
     case 0x01: {
@@ -40,14 +40,14 @@
           0x01
         )
       );
-      
+
       data_vertex_basic_textured_coloured.position_texture = (
         float2(
           0x01,
           0x01
         )
       );
-      
+
       break;
     }
     case 0x02: {
@@ -59,14 +59,14 @@
           0x01
         )
       );
-      
+
       data_vertex_basic_textured_coloured.position_texture = (
         float2(
           0x00,
           0x00
         )
       );
-      
+
       break;
     }
     case 0x03: {
@@ -78,23 +78,22 @@
           0x01
         )
       );
-      
+
       data_vertex_basic_textured_coloured.position_texture = (
         float2(
           0x01,
           0x00
         )
       );
-      
+
       break;
     }
   }
-  
+
   return (
     data_vertex_basic_textured_coloured
-  );  
+  );
 }
-
 
 [[fragment]] float4 metil_indirect_rendering_fragment(
   data_vertex_basic_textured_coloured data_vertex_basic_textured_coloured [[
@@ -115,7 +114,7 @@
     texture.sample(
       sampler_texture,
       data_vertex_basic_textured_coloured.position_texture
-    )  
+    )
   );
 }
 

--- a/sources/metil_rendering/metil_renderer.m
+++ b/sources/metil_rendering/metil_renderer.m
@@ -1375,6 +1375,9 @@
         computeCommandEncoder
       ];
 
+      id<MTLTexture> texture_input;
+      id<MTLTexture> texture_output;
+
       for (
         unsigned short int index_filter = (
           0x00
@@ -1385,6 +1388,30 @@
         );
         ++index_filter
       ) {
+        if (
+          (
+            index_filter %
+            0x02
+          ) ==
+          0x00
+        ) {
+          texture_input = (
+            self->texture_render_target
+          );
+
+          texture_output = (
+            self->texture_render_target_processed
+          );
+        } else {
+          texture_input = (
+            self->texture_render_target_processed
+          );
+
+          texture_output = (
+            self->texture_render_target
+          );
+        }
+
         struct metil_filter* metil_filter = &(
           self->filters[
             index_filter
@@ -1403,7 +1430,7 @@
         [
           encoder_command_compute
           setTexture: (
-            self->texture_render_target
+            texture_input
           )
           atIndex: (
             0x00
@@ -1420,7 +1447,7 @@
           [
             encoder_command_compute
             setTexture: (
-              self->texture_render_target_processed
+              texture_output
             )
             atIndex: (
               0x01
@@ -1430,7 +1457,7 @@
           [
             encoder_command_compute
             setTexture: (
-              self->texture_render_target
+              texture_input
             )
             atIndex: (
               0x01
@@ -1558,15 +1585,33 @@
         )
       ];
 
-      [
-        encoder_render
-        setFragmentTexture: (
-          self->texture_render_target_processed
-        )
-        atIndex: (
-          0x00
-        )
-      ];
+      if (
+        (
+          self->length_filters %
+          0x02
+        ) ==
+        0x00
+      ) {
+        [
+          encoder_render
+          setFragmentTexture: (
+            self->texture_render_target
+          )
+          atIndex: (
+            0x00
+          )
+        ];
+      } else {
+        [
+          encoder_render
+          setFragmentTexture: (
+            self->texture_render_target_processed
+          )
+          atIndex: (
+            0x00
+          )
+        ];
+      }
 
       [
         encoder_render


### PR DESCRIPTION
allows filters one after the other


example

<img width="1966" height="1250" alt="Screenshot 2026-07-01 at 03 17 33" src="https://github.com/user-attachments/assets/6238f09c-21c0-4a4e-97c4-9fc85c060846" />
<img width="1966" height="1250" alt="Screenshot 2026-07-01 at 03 17 43" src="https://github.com/user-attachments/assets/dab99142-d797-4eba-9019-ef6d41930c14" />

first filter applied is the repeat one
second filter applied is an inverse

